### PR TITLE
add LogRequest util formerly from fortio/fhttp

### DIFF
--- a/http_logging.go
+++ b/http_logging.go
@@ -1,0 +1,47 @@
+// Copyright 2017-2023 Fortio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+// TLSInfo returns " https <cipher suite>" if the request is using TLS, or "" otherwise.
+func TLSInfo(r *http.Request) string {
+	if r.TLS == nil {
+		return ""
+	}
+	return fmt.Sprintf(" https %s", tls.CipherSuiteName(r.TLS.CipherSuite))
+}
+
+// LogRequest logs the incoming request, including headers when loglevel is verbose.
+func LogRequest(r *http.Request, msg string) {
+	if Log(Info) {
+		tlsInfo := TLSInfo(r)
+		Printf("%s: %v %v %v %v (%v) %s %q%s", msg, r.Method, r.URL, r.Proto, r.RemoteAddr,
+			r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-For"), r.Header.Get("User-Agent"), tlsInfo)
+	}
+	if LogVerbose() {
+		// Host is removed from headers map and put separately
+		Printf("Header Host: %v", r.Host)
+		for name, headers := range r.Header {
+			for _, h := range headers {
+				Printf("Header %v: %v\n", name, h)
+			}
+		}
+	}
+}

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -1,0 +1,32 @@
+package log // import "fortio.org/fortio/log"
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"net/http"
+	"testing"
+)
+
+// leave this test first/where it is as it relies on line number not changing.
+// note that the real functional test is in fortio/fhttp. and this is mostly for coverage.
+func TestLogRequest(t *testing.T) {
+	SetLogLevel(Verbose) // make sure it's already debug when we capture
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	SetOutput(w)
+	SetFlags(0) // remove timestamps
+	h := http.Header{"foo": []string{"bar"}}
+	r := &http.Request{TLS: &tls.ConnectionState{}, Header: h}
+	LogRequest(r, "test1")
+	r.TLS = nil
+	r.Header = nil
+	LogRequest(r, "test2")
+	w.Flush()
+	actual := b.String()
+	expected := "test1:  <nil>   ()  \"\" https 0x0000\nHeader Host: \nHeader foo: bar\n" +
+		"test2:  <nil>   ()  \"\"\nHeader Host: \n"
+	if actual != expected {
+		t.Errorf("unexpected:\n%q\nvs:\n%q\n", actual, expected)
+	}
+}


### PR DESCRIPTION
 moved here so dflag endpoint can be independent of fortio/not make a circular dep