### PR TITLE
fix the prefix to match what it was/is expected 

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -63,7 +63,7 @@ type LogConfig struct {
 
 func DefaultConfig() *LogConfig {
 	return &LogConfig{
-		LogPrefix:      ">",
+		LogPrefix:      "> ",
 		LogFileAndLine: true,
 		FatalPanics:    true,
 		FatalExit:      os.Exit,


### PR DESCRIPTION
found through stats_test failure in https://github.com/fortio/fortio/pull/706