### PR TITLE
JSON logging, `log.S`

### DIFF
--- a/.github/workflows/gochecks.yml
+++ b/.github/workflows/gochecks.yml
@@ -1,0 +1,22 @@
+name: go-checks
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup Go environment
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          check-latest: true
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -46,13 +46,7 @@ linters-settings:
     enable-all: true
     disable-all: false
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/sirupsen/logrus
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - github.com/sirupsen/logrus: "logging is allowed only by fortio.log"
+    # new depguard default is to complain for anything not std package which works for this specific base package
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,8 @@ linters-settings:
 
 linters:
   disable:
+    # bad ones:
+    - musttag
     # Deprecated ones:
     - scopelint
     - golint

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ See the `Config` object for options like whether to include line number and file
 New since 1.4 server logging (as used in [fortio.org/scli](https://pkg.go.dev/fortio.org/scli#ServerMain) for instance) is now structured (json), client logging (as setup by [fortio.org/cli](https://pkg.go.dev/fortio.org/scli#ServerMain) remains as before.
 
 One can also revert server to not be JSON through config.
+
+In JSON mode the output looks like this
+```json
+{"ts":1683504169239557,"level":"info","file":"logger.go","line":221,"msg":"Log level is now 1 Verbose (was 2 Info"}
+```
+Which can be converted to JSONEntry but is also a fixed, optimized format (ie ts is always first etc)
+
+The timestamp `ts` is in microseconds since epoch (golang UnixMicro())

--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ log.LogRequest(r, "some info")
 ```
 
 See the `Config` object for options like whether to include line number and file name of caller or not etc
+
+New since 1.4 server logging (as used in [fortio.org/scli](https://pkg.go.dev/fortio.org/scli#ServerMain) for instance) is now structured (json), client logging (as setup by [fortio.org/cli](https://pkg.go.dev/fortio.org/scli#ServerMain) remains as before.
+
+One can also revert server to not be JSON through config.

--- a/README.md
+++ b/README.md
@@ -42,3 +42,5 @@ In JSON mode the output looks like this
 Which can be converted to JSONEntry but is also a fixed, optimized format (ie ts is always first etc)
 
 The timestamp `ts` is in microseconds since epoch (golang UnixMicro())
+
+Optional additional `KeyValue` pairs can be added to the base structure using the new `log.LogS` or passed to `log.LogRequest`.

--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Which can be converted to JSONEntry but is also a fixed, optimized format (ie ts
 
 The timestamp `ts` is in microseconds since epoch (golang UnixMicro())
 
-Optional additional `KeyValue` pairs can be added to the base structure using the new `log.LogS` or passed to `log.LogRequest`.
+Optional additional `KeyValue` pairs can be added to the base structure using the new `log.S` or passed to `log.LogRequest`.

--- a/http_logging.go
+++ b/http_logging.go
@@ -48,6 +48,7 @@ func AppendTLSInfoAttrs(attrs []KeyVal, r *http.Request) []KeyVal {
 
 // LogRequest logs the incoming request, TLSInfo,
 // including headers when loglevel is verbose.
+// additional key:value pairs can be passed as extraAttributes.
 func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 	if !Log(Info) {
 		return

--- a/http_logging.go
+++ b/http_logging.go
@@ -49,14 +49,18 @@ func AppendTLSInfoAttrs(attrs []KeyVal, r *http.Request) []KeyVal {
 // LogRequest logs the incoming request, TLSInfo,
 // including headers when loglevel is verbose.
 // additional key:value pairs can be passed as extraAttributes.
+//
+//nolint:revive
 func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 	if !Log(Info) {
 		return
 	}
-	attr := []KeyVal{Str("method", r.Method), Attr("url", r.URL), Str("proto", r.Proto),
+	attr := []KeyVal{
+		Str("method", r.Method), Attr("url", r.URL), Str("proto", r.Proto),
 		Str("remote_addr", r.RemoteAddr), Str("header.x-forwarded-proto", r.Header.Get("X-Forwarded-Proto")),
 		Str("header.x-forwarded-for", r.Header.Get("X-Forwarded-For")),
-		Str("user-agent", r.Header.Get("User-Agent"))}
+		Str("user-agent", r.Header.Get("User-Agent")),
+	}
 	attr = AppendTLSInfoAttrs(attr, r)
 	attr = append(attr, extraAttributes...)
 	if LogVerbose() {
@@ -66,5 +70,5 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 			attr = append(attr, Str("header."+name, strings.Join(headers, ",")))
 		}
 	}
-	LogS(Info, msg, attr...)
+	S(Info, msg, attr...)
 }

--- a/http_logging.go
+++ b/http_logging.go
@@ -18,10 +18,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"strings"
 )
 
 // TLSInfo returns ' https <cipher suite> "<peer CN>"' if the request is using TLS
 // (and ' "<peer CN>"' part if mtls / a peer certificate is present) or "" otherwise.
+// Use [AppendTLSInfoAttrs] unless you do want to just output text.
 func TLSInfo(r *http.Request) string {
 	if r.TLS == nil {
 		return ""
@@ -33,23 +35,35 @@ func TLSInfo(r *http.Request) string {
 	return fmt.Sprintf(" https %s%s", tls.CipherSuiteName(r.TLS.CipherSuite), cliCert)
 }
 
+func AppendTLSInfoAttrs(attrs []KeyVal, r *http.Request) []KeyVal {
+	if r.TLS == nil {
+		return attrs
+	}
+	attrs = append(attrs, Attr("tls", true))
+	if len(r.TLS.PeerCertificates) > 0 {
+		attrs = append(attrs, Str("tls.peer_cn", r.TLS.PeerCertificates[0].Subject.CommonName))
+	}
+	return attrs
+}
+
 // LogRequest logs the incoming request, TLSInfo,
 // including headers when loglevel is verbose.
-//
-//nolint:revive
-func LogRequest(r *http.Request, msg string) {
-	if Log(Info) {
-		tlsInfo := TLSInfo(r)
-		Printf("%s: %v %v %v %v (%v) %s %q%s", msg, r.Method, r.URL, r.Proto, r.RemoteAddr,
-			r.Header.Get("X-Forwarded-Proto"), r.Header.Get("X-Forwarded-For"), r.Header.Get("User-Agent"), tlsInfo)
+func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
+	if !Log(Info) {
+		return
 	}
+	attr := []KeyVal{Str("method", r.Method), Attr("url", r.URL), Str("proto", r.Proto),
+		Str("remote_addr", r.RemoteAddr), Str("header.x-forwarded-proto", r.Header.Get("X-Forwarded-Proto")),
+		Str("header.x-forwarded-for", r.Header.Get("X-Forwarded-For")),
+		Str("user-agent", r.Header.Get("User-Agent"))}
+	attr = AppendTLSInfoAttrs(attr, r)
+	attr = append(attr, extraAttributes...)
 	if LogVerbose() {
 		// Host is removed from headers map and put separately
-		Printf("Header Host: %v", r.Host)
+		attr = append(attr, Str("header.host", r.Host))
 		for name, headers := range r.Header {
-			for _, h := range headers {
-				Printf("Header %v: %v\n", name, h)
-			}
+			attr = append(attr, Str("header."+name, strings.Join(headers, ",")))
 		}
 	}
+	LogS(Info, msg, attr...)
 }

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -8,28 +8,66 @@ import (
 	"crypto/x509/pkix"
 	"net/http"
 	"testing"
+	"time"
 )
 
-// leave this test first/where it is as it relies on line number not changing.
 // note that the real functional test is in fortio/fhttp. and this is mostly for coverage.
 func TestLogRequest(t *testing.T) {
 	SetLogLevel(Verbose) // make sure it's already debug when we capture
+	Config.LogFileAndLine = false
+	Config.Structured = true
+	nowFunction = func() time.Time { return time.Unix(1234567890, 0) }
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
-	SetFlags(0) // remove timestamps
-	h := http.Header{"foo": []string{"bar"}}
+	h := http.Header{"foo": []string{"bar1", "bar2"}}
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "x\nyz"}} // make sure special chars are escaped
 	r := &http.Request{TLS: &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}, Header: h}
 	LogRequest(r, "test1")
 	r.TLS = nil
 	r.Header = nil
-	LogRequest(r, "test2")
+	LogRequest(r, "test2", Str("extra1", "v1"), Str("extra2", "v2"))
+	nowFunction = time.Now // restore normal clock (used by other tests)
 	w.Flush()
 	actual := b.String()
-	expected := "test1:  <nil>   ()  \"\" https 0x0000 \"CN=x\\nyz\"\nHeader Host: \nHeader foo: bar\n" +
-		"test2:  <nil>   ()  \"\"\nHeader Host: \n"
+	expected := `{"ts":1234567890000000,"level":"info","msg":"test1","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":"true","tls.peer_cn":"x\nyz","header.host":"","header.foo":"bar1,bar2"}
+{"ts":1234567890000000,"level":"info","msg":"test2","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2","header.host":""}
+`
 	if actual != expected {
-		t.Errorf("unexpected:\n%q\nvs:\n%q\n", actual, expected)
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
+	}
+}
+
+func TestLogRequestNoLog(t *testing.T) {
+	SetLogLevel(Warning) // make sure it's already debug when we capture
+	Config.LogFileAndLine = false
+	Config.Structured = true
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	SetOutput(w)
+	r := &http.Request{}
+	LogRequest(r, "test1")
+	w.Flush()
+	actual := b.String()
+	if actual != "" {
+		t.Errorf("unexpected: %q", actual)
+	}
+}
+
+// Test for the "old" TLSInfo
+func TestTLSInfo(t *testing.T) {
+	h := http.Header{"foo": []string{"bar"}}
+	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "x\nyz"}} // make sure special chars are escaped
+	r := &http.Request{TLS: &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}, Header: h}
+	got := TLSInfo(r)
+	expected := " https 0x0000 \"CN=x\\nyz\""
+	if got != expected {
+		t.Errorf("unexpected for tls:\n%s\nvs:\n%s\n", got, expected)
+	}
+	r.TLS = nil
+	got = TLSInfo(r)
+	expected = ""
+	if got != expected {
+		t.Errorf("unexpected for no tls:\n%s\nvs:\n%s\n", got, expected)
 	}
 }

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// note that the real functional test is in fortio/fhttp. and this is mostly for coverage.
+// There is additional functional testing in fortio.org/fortio/fhttp.
 func TestLogRequest(t *testing.T) {
 	SetLogLevel(Verbose) // make sure it's already debug when we capture
 	Config.LogFileAndLine = false
@@ -30,6 +30,7 @@ func TestLogRequest(t *testing.T) {
 	nowFunction = time.Now // restore normal clock (used by other tests)
 	w.Flush()
 	actual := b.String()
+	//nolint: lll
 	expected := `{"ts":1234567890000000,"level":"info","msg":"test1","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":"true","tls.peer_cn":"x\nyz","header.host":"","header.foo":"bar1,bar2"}
 {"ts":1234567890000000,"level":"info","msg":"test2","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2","header.host":""}
 `
@@ -54,7 +55,7 @@ func TestLogRequestNoLog(t *testing.T) {
 	}
 }
 
-// Test for the "old" TLSInfo
+// Test for the "old" TLSInfo.
 func TestTLSInfo(t *testing.T) {
 	h := http.Header{"foo": []string{"bar"}}
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "x\nyz"}} // make sure special chars are escaped

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -15,7 +15,7 @@ import (
 func TestLogRequest(t *testing.T) {
 	SetLogLevel(Verbose) // make sure it's already debug when we capture
 	Config.LogFileAndLine = false
-	Config.Structured = true
+	Config.JSON = true
 	nowFunction = func() time.Time { return time.Unix(1234567890, 0) }
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -41,7 +41,7 @@ func TestLogRequest(t *testing.T) {
 func TestLogRequestNoLog(t *testing.T) {
 	SetLogLevel(Warning) // make sure it's already debug when we capture
 	Config.LogFileAndLine = false
-	Config.Structured = true
+	Config.JSON = true
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"net/http"
 	"testing"
-	"time"
 )
 
 // There is additional functional testing in fortio.org/fortio/fhttp.
@@ -16,7 +15,7 @@ func TestLogRequest(t *testing.T) {
 	SetLogLevel(Verbose) // make sure it's already debug when we capture
 	Config.LogFileAndLine = false
 	Config.JSON = true
-	nowFunction = func() time.Time { return time.Unix(1234567890, 0) }
+	Config.NoTimestamp = true
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
@@ -27,12 +26,11 @@ func TestLogRequest(t *testing.T) {
 	r.TLS = nil
 	r.Header = nil
 	LogRequest(r, "test2", Str("extra1", "v1"), Str("extra2", "v2"))
-	nowFunction = time.Now // restore normal clock (used by other tests)
 	w.Flush()
 	actual := b.String()
 	//nolint: lll
-	expected := `{"ts":1234567890000000,"level":"info","msg":"test1","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":"true","tls.peer_cn":"x\nyz","header.host":"","header.foo":"bar1,bar2"}
-{"ts":1234567890000000,"level":"info","msg":"test2","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2","header.host":""}
+	expected := `{"level":"info","msg":"test1","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":"true","tls.peer_cn":"x\nyz","header.host":"","header.foo":"bar1,bar2"}
+{"level":"info","msg":"test2","method":"","url":"<nil>","proto":"","remote_addr":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2","header.host":""}
 `
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)

--- a/logger.go
+++ b/logger.go
@@ -289,13 +289,11 @@ func TimeToTS(t time.Time) int64 {
 	return t.UnixMicro()
 }
 
-var nowFunction = time.Now // for setting a fixed time for tests
-
 func jsonTimestamp() string {
 	if Config.NoTimestamp {
 		return ""
 	}
-	return fmt.Sprintf("\"ts\":%d,", TimeToTS(nowFunction()))
+	return fmt.Sprintf("\"ts\":%d,", TimeToTS(time.Now()))
 }
 
 func logPrintf(lvl Level, format string, rest ...interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -241,7 +241,7 @@ func setLogLevel(lvl Level, logChange bool) Level {
 	}
 	if lvl != prev {
 		if logChange {
-			logPrintf(Info, "Log level is now %d %s (was %d %s)\n", lvl, lvl.String(), prev, prev.String())
+			logPrintf(Info, "Log level is now %d %s (was %d %s)", lvl, lvl.String(), prev, prev.String())
 		}
 		setLevel(lvl)
 	}

--- a/logger.go
+++ b/logger.go
@@ -458,7 +458,7 @@ func Attr[T ValueTypes](key string, value T) KeyVal {
 	}
 }
 
-func LogS(lvl Level, msg string, attrs ...KeyVal) {
+func S(lvl Level, msg string, attrs ...KeyVal) {
 	if !Log(lvl) {
 		return
 	}

--- a/logger.go
+++ b/logger.go
@@ -120,7 +120,8 @@ type JSONEntry struct {
 	Line  int
 	Msg   string
 	// + additional optional fields
-	// See https://go.dev/play/p/oPK5vyUH2tf for a possibility
+	// See https://go.dev/play/p/oPK5vyUH2tf for a possibility (using https://github.com/devnw/ajson )
+	// or https://go.dev/play/p/H0RPmuc3dzv (using github.com/mitchellh/mapstructure)
 }
 
 // LogEntry Ts to time.Time conversion.

--- a/logger.go
+++ b/logger.go
@@ -289,11 +289,13 @@ func TimeToTS(t time.Time) int64 {
 	return t.UnixMicro()
 }
 
+var nowFunction = time.Now // for setting a fixed time for tests
+
 func jsonTimestamp() string {
 	if Config.NoTimestamp {
 		return ""
 	}
-	return fmt.Sprintf("\"ts\":%d,", TimeToTS(time.Now()))
+	return fmt.Sprintf("\"ts\":%d,", TimeToTS(nowFunction()))
 }
 
 func logPrintf(lvl Level, format string, rest ...interface{}) {

--- a/logger.go
+++ b/logger.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -271,9 +272,12 @@ func Logf(lvl Level, format string, rest ...interface{}) {
 
 // Used when doing our own logging writing, in structured mode.
 var jsonWriter io.Writer = os.Stderr
+var jsonWriterMutex sync.Mutex
 
 func jsonWrite(msg string) {
-	jsonWriter.Write([]byte(msg))
+	jsonWriterMutex.Lock()
+	_, _ = jsonWriter.Write([]byte(msg)) // if we get errors while logging... can't quite ... log errors
+	jsonWriterMutex.Unlock()
 }
 
 func TimeToTs(t time.Time) int64 {

--- a/logger_test.go
+++ b/logger_test.go
@@ -42,11 +42,11 @@ func TestLoggerFilenameLine(t *testing.T) {
 	SetFlags(0)
 	SetLogLevel(Debug)
 	if LogDebug() {
-		Debugf("test") // line 44
+		Debugf("test") // line 45
 	}
 	w.Flush()
 	actual := b.String()
-	expected := "D logger_test.go:44-prefix-test\n"
+	expected := "D logger_test.go:45-prefix-test\n"
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
 	}
@@ -65,11 +65,11 @@ func TestLoggerFilenameLineJSON(t *testing.T) {
 	SetOutput(w)
 	SetLogLevel(Debug)
 	if LogDebug() {
-		Debugf("a test") // line 67
+		Debugf("a test") // line 68
 	}
 	w.Flush()
 	actual := b.String()
-	expected := `{"level":"dbug","file":"logger_test.go","line":67,"msg":"a test"}` + "\n"
+	expected := `{"level":"dbug","file":"logger_test.go","line":68,"msg":"a test"}` + "\n"
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -171,7 +171,7 @@ func TestLoggerJSON(t *testing.T) {
 	}
 	_ = w.Flush()
 	actual := b.String()
-	e := LogEntry{}
+	e := JSONEntry{}
 	err := json.Unmarshal([]byte(actual), &e)
 	t.Logf("got: %s -> %#v", actual, e)
 	if err != nil {
@@ -213,7 +213,7 @@ func TestLoggerJSONNoTimestampNoFilename(t *testing.T) {
 	Critf("Test Critf")
 	_ = w.Flush()
 	actual := b.String()
-	e := LogEntry{}
+	e := JSONEntry{}
 	err := json.Unmarshal([]byte(actual), &e)
 	t.Logf("got: %s -> %#v", actual, e)
 	if err != nil {
@@ -231,18 +231,18 @@ func TestLoggerJSONNoTimestampNoFilename(t *testing.T) {
 	if e.Line != 0 {
 		t.Errorf("unexpected line %d", e.Line)
 	}
-	if e.Ts != 0 {
-		t.Errorf("unexpected time should be absent, got %v %v", e.Ts, e.Time())
+	if e.TS != 0 {
+		t.Errorf("unexpected time should be absent, got %v %v", e.TS, e.Time())
 	}
 }
 
-// Test that TimeToTs and Time() are inverse of one another
+// Test that TimeToTs and Time() are inverse of one another.
 func TestTimeToTs(t *testing.T) {
 	// tight loop to get different times, at highest resolution
 	for i := 0; i < 1000; i++ {
 		now := time.Now()
-		int64Ts := TimeToTs(now)
-		e := LogEntry{Ts: int64Ts}
+		int64Ts := TimeToTS(now)
+		e := JSONEntry{TS: int64Ts}
 		inv := e.Time()
 		// Round to microsecond because that's the resolution of the timestamp
 		// (note that on a mac for instance, there is no nanosecond resolution anyway)
@@ -257,7 +257,7 @@ func microsecondResolution(t time.Time) time.Time {
 	return t.Truncate(1 * time.Microsecond)
 }
 
-// concurrency test, make sure json aren't mixed up
+// concurrency test, make sure json aren't mixed up.
 func TestLoggerJSONConcurrency(t *testing.T) {
 	// Setup
 	var b bytes.Buffer
@@ -290,7 +290,7 @@ func TestLoggerJSONConcurrency(t *testing.T) {
 			continue
 		}
 		count++
-		e := LogEntry{}
+		e := JSONEntry{}
 		err := json.Unmarshal([]byte(line), &e)
 		if err != nil {
 			t.Errorf("unexpected JSON deserialization error on line %d %v for %q", count, err, line)

--- a/logger_test.go
+++ b/logger_test.go
@@ -189,10 +189,11 @@ func TestLoggerJSON(t *testing.T) {
 		t.Errorf("unexpected line %d", e.Line)
 	}
 	ts := e.Time()
+	now = microsecondResolution(now) // truncates so can't be after ts
 	if now.After(ts) {
 		t.Errorf("unexpected time %v is after %v", now, ts)
 	}
-	if ts.Sub(now) > 1*time.Second {
+	if ts.Sub(now) > 100*time.Millisecond {
 		t.Errorf("unexpected time %v is > 1sec after %v", ts, now)
 	}
 }
@@ -244,10 +245,15 @@ func TestTimeToTs(t *testing.T) {
 		inv := e.Time()
 		// Round to microsecond because that's the resolution of the timestamp
 		// (note that on a mac for instance, there is no nanosecond resolution anyway)
-		if !now.Round(1 * time.Microsecond).Equal(inv.Round(1 * time.Microsecond)) {
+		if !microsecondResolution(now).Equal(inv) {
 			t.Fatalf("unexpected time %v != %v (%d)", now, inv, int64Ts)
 		}
 	}
+}
+
+func microsecondResolution(t time.Time) time.Time {
+	// Truncate and not Round because that's what UnixMicro does (indirectly).
+	return t.Truncate(1 * time.Microsecond)
 }
 
 func TestLogFatal(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -29,6 +29,8 @@ import (
 	"time"
 )
 
+const thisFilename = "logger_test.go"
+
 // leave this test first/where it is as it relies on line number not changing.
 func TestLoggerFilenameLine(t *testing.T) {
 	SetLogLevel(Debug) // make sure it's already debug when we capture
@@ -42,11 +44,11 @@ func TestLoggerFilenameLine(t *testing.T) {
 	SetFlags(0)
 	SetLogLevel(Debug)
 	if LogDebug() {
-		Debugf("test") // line 45
+		Debugf("test") // line 47
 	}
 	w.Flush()
 	actual := b.String()
-	expected := "D logger_test.go:45-prefix-test\n"
+	expected := "D logger_test.go:47-prefix-test\n"
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
 	}
@@ -65,11 +67,11 @@ func TestLoggerFilenameLineJSON(t *testing.T) {
 	SetOutput(w)
 	SetLogLevel(Debug)
 	if LogDebug() {
-		Debugf("a test") // line 68
+		Debugf("a test") // line 70
 	}
 	w.Flush()
 	actual := b.String()
-	expected := `{"level":"dbug","file":"logger_test.go","line":68,"msg":"a test"}` + "\n"
+	expected := `{"level":"dbug","file":"` + thisFilename + `","line":70,"msg":"a test"}` + "\n"
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
 	}
@@ -87,11 +89,11 @@ func Test_LogS_JSON_no_json_with_filename(t *testing.T) {
 	log.SetFlags(0)
 	SetOutput(w)
 	// Start of the actual test
-	LogS(Verbose, "This won't show")
-	LogS(Warning, "This will show", Str("key1", "value 1"), Attr("key2", 42)) // line 91
+	S(Verbose, "This won't show")
+	S(Warning, "This will show", Str("key1", "value 1"), Attr("key2", 42)) // line 93
 	_ = w.Flush()
 	actual := b.String()
-	expected := "W logger_test.go:91-bar-This will show, key1=value 1, key2=42\n"
+	expected := "W logger_test.go:93-bar-This will show, key1=value 1, key2=42\n"
 	if actual != expected {
 		t.Errorf("got %q expected %q", actual, expected)
 	}
@@ -205,7 +207,7 @@ func TestLoggerJSON(t *testing.T) {
 	if e.Msg != "Test Verbose 0" {
 		t.Errorf("unexpected body %s", e.Msg)
 	}
-	if e.File != "logger_test.go" {
+	if e.File != thisFilename {
 		t.Errorf("unexpected file %q", e.File)
 	}
 	if e.Line < 150 || e.Line > 200 {
@@ -234,7 +236,7 @@ func Test_LogS_JSON(t *testing.T) {
 	now := time.Now()
 	value2 := 42
 	value3 := 3.14
-	LogS(Verbose, "Test Verbose", Str("key1", "value 1"), Attr("key2", value2), Attr("key3", value3))
+	S(Verbose, "Test Verbose", Str("key1", "value 1"), Attr("key2", value2), Attr("key3", value3))
 	_ = w.Flush()
 	actual := b.String()
 	e := JSONEntry{}
@@ -249,7 +251,7 @@ func Test_LogS_JSON(t *testing.T) {
 	if e.Msg != "Test Verbose" {
 		t.Errorf("unexpected body %s", e.Msg)
 	}
-	if e.File != "logger_test.go" {
+	if e.File != thisFilename {
 		t.Errorf("unexpected file %q", e.File)
 	}
 	if e.Line < 200 || e.Line > 250 {
@@ -279,7 +281,7 @@ func Test_LogS_JSON(t *testing.T) {
 	if tmp["key3"] != "3.14" {
 		t.Errorf("unexpected key3 %v", tmp["key3"])
 	}
-	if tmp["file"] != "logger_test.go" {
+	if tmp["file"] != thisFilename {
 		t.Errorf("unexpected file %v", tmp["file"])
 	}
 }
@@ -294,8 +296,8 @@ func Test_LogS_JSON_no_file(t *testing.T) {
 	Config.NoTimestamp = false
 	SetOutput(w)
 	// Start of the actual test
-	LogS(Verbose, "This won't show")
-	LogS(Warning, "This will show", Attr("key1", "value 1"))
+	S(Verbose, "This won't show")
+	S(Warning, "This will show", Attr("key1", "value 1"))
 	_ = w.Flush()
 	actual := b.String()
 	var tmp map[string]interface{}
@@ -323,8 +325,8 @@ func Test_LogS_JSON_no_json_no_file(t *testing.T) {
 	log.SetFlags(0)
 	SetOutput(w)
 	// Start of the actual test
-	LogS(Verbose, "This won't show")
-	LogS(Warning, "This will show", Str("key1", "value 1"), Attr("key2", 42))
+	S(Verbose, "This won't show")
+	S(Warning, "This will show", Str("key1", "value 1"), Attr("key2", 42))
 	_ = w.Flush()
 	actual := b.String()
 	expected := "W -foo-This will show, key1=value 1, key2=42\n"

--- a/logger_test.go
+++ b/logger_test.go
@@ -35,7 +35,7 @@ func TestLoggerFilenameLine(t *testing.T) {
 	on := true
 	Config.LogFileAndLine = on
 	Config.LogPrefix = "-prefix-"
-	Config.Structured = false
+	Config.JSON = false
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
@@ -58,7 +58,7 @@ func TestLoggerFilenameLineJSON(t *testing.T) {
 	on := true
 	Config.LogFileAndLine = on
 	Config.LogPrefix = "-not used-"
-	Config.Structured = true
+	Config.JSON = true
 	Config.NoTimestamp = true
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
@@ -81,7 +81,7 @@ func Test_LogS_JSON_no_json_with_filename(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	SetLogLevel(LevelByName("Warning"))
 	Config.LogFileAndLine = true
-	Config.Structured = false
+	Config.JSON = false
 	Config.NoTimestamp = false
 	Config.LogPrefix = "-bar-"
 	log.SetFlags(0)
@@ -120,7 +120,7 @@ func TestLogger1(t *testing.T) {
 	SetLogLevel(Info) // reset from other tests
 	Config.LogFileAndLine = false
 	Config.LogPrefix = ""
-	Config.Structured = false
+	Config.JSON = false
 	SetOutput(w)
 	log.SetFlags(0)
 	// Start of the actual test
@@ -183,7 +183,7 @@ func TestLoggerJSON(t *testing.T) {
 	SetLogLevel(LevelByName("Verbose"))
 	Config.LogFileAndLine = true
 	Config.LogPrefix = "no used"
-	Config.Structured = true
+	Config.JSON = true
 	Config.NoTimestamp = false
 	SetOutput(w)
 	// Start of the actual test
@@ -227,7 +227,7 @@ func Test_LogS_JSON(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	SetLogLevel(LevelByName("Verbose"))
 	Config.LogFileAndLine = true
-	Config.Structured = true
+	Config.JSON = true
 	Config.NoTimestamp = false
 	SetOutput(w)
 	// Start of the actual test
@@ -290,7 +290,7 @@ func Test_LogS_JSON_no_file(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	SetLogLevel(LevelByName("Warning"))
 	Config.LogFileAndLine = false
-	Config.Structured = true
+	Config.JSON = true
 	Config.NoTimestamp = false
 	SetOutput(w)
 	// Start of the actual test
@@ -317,7 +317,7 @@ func Test_LogS_JSON_no_json_no_file(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	SetLogLevel(LevelByName("Warning"))
 	Config.LogFileAndLine = false
-	Config.Structured = false
+	Config.JSON = false
 	Config.NoTimestamp = false
 	Config.LogPrefix = "-foo-"
 	log.SetFlags(0)
@@ -340,7 +340,7 @@ func TestLoggerJSONNoTimestampNoFilename(t *testing.T) {
 	SetLogLevel(LevelByName("Verbose"))
 	Config.LogFileAndLine = false
 	Config.LogPrefix = "no used"
-	Config.Structured = true
+	Config.JSON = true
 	Config.NoTimestamp = true
 	SetOutput(w)
 	// Start of the actual test
@@ -399,7 +399,7 @@ func TestLoggerJSONConcurrency(t *testing.T) {
 	SetLogLevel(LevelByName("Verbose"))
 	Config.LogFileAndLine = true
 	Config.NoTimestamp = true
-	Config.Structured = true
+	Config.JSON = true
 	SetOutput(w)
 	// Start of the actual test
 	var wg sync.WaitGroup


### PR DESCRIPTION
Alternative to https://pkg.go.dev/golang.org/x/exp/slog but handcrafted JSON output instead

- [x] base: ts, level, file, line, msg hand emitted/fast JSON
- [x] extensibility? ie how to make for instance LogRequest also emit individual fields; in structured version: `log.S` does
- [x] follow up with checking https://github.com/go-json-experiment/json and https://github.com/devnw/ajson and https://github.com/mitchellh/mapstructure - deferred as we don't deserialize ourselves
- [x] use structured log for LogRequest()
- [x] check what to do with panic() - defer, panic will be unstructured for now
- [ ] good candidate for fuzzing?
- [ ] maybe have a better set than just Str(key,value) and Attr(key,value) that preserves type of some values (numbers - though there are issues with that and NaN, precision etc)

Fixes #21