### PR TITLE
using sec.usec as format instead of usec since epoch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ One can also revert server to not be JSON through config.
 
 In JSON mode the output looks like this
 ```json
-{"ts":1683504169239557,"level":"info","file":"logger.go","line":221,"msg":"Log level is now 1 Verbose (was 2 Info"}
+{"ts":1683504169.239557,"level":"info","file":"logger.go","line":221,"msg":"Log level is now 1 Verbose (was 2 Info"}
 ```
 Which can be converted to JSONEntry but is also a fixed, optimized format (ie ts is always first etc)
 

--- a/logger.go
+++ b/logger.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"os"
 	"runtime"
 	"strings"
@@ -114,7 +115,7 @@ func SetDefaultsForClientTools() {
 // While that serialization of is custom in order to be cheap, it maps to the following
 // structure.
 type JSONEntry struct {
-	TS    int64 // in microseconds since epoch (unix micros)
+	TS    float64 // in seconds since epoch (unix micros)
 	Level string
 	File  string
 	Line  int
@@ -127,10 +128,10 @@ type JSONEntry struct {
 // LogEntry Ts to time.Time conversion.
 // The returned time is set UTC to avoid TZ mismatch.
 func (l *JSONEntry) Time() time.Time {
-	const million = int64(1e6)
+	sec := int64(l.TS)
 	return time.Unix(
-		l.TS/million,        // Microseconds -> Seconds
-		1000*(l.TS%million), // Microseconds -> Nanoseconds
+		sec, // float seconds -> int Seconds
+		int64(math.Round(1e6*(l.TS-float64(sec)))*1000), // reminder -> Nanoseconds
 	)
 }
 
@@ -285,15 +286,24 @@ func jsonWrite(msg string) {
 	jsonWriterMutex.Unlock()
 }
 
-func TimeToTS(t time.Time) int64 {
-	return t.UnixMicro()
+func TimeToTS(t time.Time) float64 {
+	// note that nanos like 1688763601.199999400 become 1688763601.1999996 in float64 (!)
+	// so we use UnixMicro to hide this problem which also means we don't give the nearest
+	// microseconds but it gets truncated instead ( https://go.dev/play/p/rzojmE2odlg )
+	usec := t.UnixMicro()
+	tfloat := float64(usec) / 1e6
+	return tfloat
+}
+
+func TimeToTStr(t time.Time) string {
+	return fmt.Sprintf("%.6f", TimeToTS(t))
 }
 
 func jsonTimestamp() string {
 	if Config.NoTimestamp {
 		return ""
 	}
-	return fmt.Sprintf("\"ts\":%d,", TimeToTS(time.Now()))
+	return fmt.Sprintf("\"ts\":%.6f,", TimeToTS(time.Now()))
 }
 
 func logPrintf(lvl Level, format string, rest ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -399,7 +399,7 @@ func TestTimeToTs(t *testing.T) {
 		inv := e.Time()
 		// Round to microsecond because that's the resolution of the timestamp
 		// (note that on a mac for instance, there is no nanosecond resolution anyway)
-		if microsecondResolution(now).Equal(inv) {
+		if !microsecondResolution(now).Equal(inv) {
 			t.Fatalf("[at %d] unexpected time %v -> %v != %v (%v %v)", i, now, microsecondResolution(now), inv, usecTS, usecTSstr)
 		}
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -389,7 +389,7 @@ func TestTimeToTs(t *testing.T) {
 	for i := 0; i < 100000; i++ {
 		now := time.Now()
 		// now = now.Add(69 * time.Nanosecond)
-		usecTSstr := TimeToTStr(now)
+		usecTSstr := timeToTStr(now)
 		usecTS, _ := strconv.ParseFloat(usecTSstr, 64)
 		if i != 0 && usecTS < prev {
 			t.Fatalf("clock went back in time at iter %d %v vs %v", i, usecTS, prev)
@@ -570,7 +570,7 @@ func TestTimeToTS(t *testing.T) {
 		{1688763601, 200000999, "1688763601.200000"}, // boundary
 	} {
 		tm := time.Unix(tst.sec, tst.nano)
-		ts := TimeToTStr(tm)
+		ts := timeToTStr(tm)
 		if ts != tst.result {
 			t.Errorf("unexpected ts for %d, %d -> %q instead of %q (%v)", tst.sec, tst.nano, ts, tst.result, tm)
 		}


### PR DESCRIPTION
Matches uber zap as well as some expected format from loki/grafana

- weirdness with nanos but works with truncated micros