### PR TITLE
use shorter field for goroutineid : grid to r

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Which can be converted to JSONEntry but is also a fixed, optimized format (ie ts
 
 The timestamp `ts` is in seconds.microseconds since epoch (golang UnixMicro() split into seconds part before decimal and microseconds after)
 
-Since 1.8 the Goroutine ID is present in json or colorized log output (for multi threaded server types).
+Since 1.8 the Go Routine ID is present in json (`r` field) or colorized log output (for multi threaded server types).
 
 Optional additional `KeyValue` pairs can be added to the base structure using the new `log.S` or passed to `log.LogRequest` using `log.Attr` and `log.Str`.
 
@@ -54,16 +54,16 @@ If console output is detected (and ConsoleColor is true, which is the default) o
 
 When output is redirected, JSON output:
 ```json
-{"ts":1689982778.034675,"level":"dbug","grid":1,"file":"levels.go","line":16,"msg":"This is a debug message ending with backslash \\"}
-{"ts":1689982778.034703,"level":"trace","grid":1,"file":"levels.go","line":17,"msg":"This is a verbose message"}
-{"ts":1689982778.034707,"level":"info","grid":1,"msg":"This an always printed, file:line omitted message"}
-{"ts":1689982778.034710,"level":"info","grid":1,"file":"levels.go","line":19,"msg":"This is an info message with no attributes but with \"quotes\"..."}
-{"ts":1689982778.034716,"level":"info","grid":1,"file":"levels.go","line":20,"msg":"This is multi line\n\tstructured info message with 3 attributes","attr1":"value1","attr2":"42","attr3":"\"quoted\nvalue\""}
-{"ts":1689982778.034721,"level":"warn","grid":1,"file":"levels.go","line":22,"msg":"This is a warning message"}
-{"ts":1689982778.034723,"level":"err","grid":1,"file":"levels.go","line":23,"msg":"This is an error message"}
-{"ts":1689982778.034726,"level":"crit","grid":1,"file":"levels.go","line":24,"msg":"This is a critical message"}
-{"ts":1689982778.034728,"level":"fatal","grid":1,"file":"levels.go","line":25,"msg":"This is a fatal message"}
-This is stdout normal output
+{"ts":1689986143.463329,"level":"dbug","r":1,"file":"levels.go","line":16,"msg":"This is a debug message ending with backslash \\"}
+{"ts":1689986143.463374,"level":"trace","r":1,"file":"levels.go","line":17,"msg":"This is a verbose message"}
+{"ts":1689986143.463378,"level":"info","r":1,"msg":"This an always printed, file:line omitted message"}
+{"ts":1689986143.463382,"level":"info","r":1,"file":"levels.go","line":19,"msg":"This is an info message with no attributes but with \"quotes\"..."}
+{"ts":1689986143.463389,"level":"info","r":1,"file":"levels.go","line":20,"msg":"This is multi line\n\tstructured info message with 3 attributes","attr1":"value1","attr2":"42","attr3":"\"quoted\nvalue\""}
+{"ts":1689986143.463396,"level":"warn","r":1,"file":"levels.go","line":22,"msg":"This is a warning message"}
+{"ts":1689986143.4634,"level":"err","r":1,"file":"levels.go","line":23,"msg":"This is an error message"}
+{"ts":1689986143.463403,"level":"crit","r":1,"file":"levels.go","line":24,"msg":"This is a critical message"}
+{"ts":1689986143.463406,"level":"fatal","r":1,"file":"levels.go","line":25,"msg":"This is a fatal message"}
+This is a non json output, will get prefixed with a exclamation point with logc
 ```
 
 When on console:

--- a/logger.go
+++ b/logger.go
@@ -134,7 +134,7 @@ func SetDefaultsForClientTools() {
 // structure.
 type JSONEntry struct {
 	TS    float64 // In seconds since epoch (unix micros resolution), see TimeToTS().
-	GrID  int64   // Goroutine ID (if enabled)
+	R     int64   // Goroutine ID (if enabled)
 	Level string
 	File  string
 	Line  int
@@ -342,7 +342,7 @@ func jsonGID() string {
 	if !Config.GoroutineID {
 		return ""
 	}
-	return fmt.Sprintf("\"grid\":%d,", goroutine.ID())
+	return fmt.Sprintf("\"r\":%d,", goroutine.ID())
 }
 
 func logPrintf(lvl Level, format string, rest ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -86,7 +86,7 @@ func TestLoggerFilenameLineJSON(t *testing.T) {
 	if grID <= 0 {
 		t.Errorf("unexpected goroutine id %d", grID)
 	}
-	expected := `{"level":"dbug","grid":` + strconv.FormatInt(grID, 10) +
+	expected := `{"level":"dbug","r":` + strconv.FormatInt(grID, 10) +
 		`,"file":"` + thisFilename + `","line":81,"msg":"a test"}` + "\n"
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)


### PR DESCRIPTION
having all these "grid": turns out to be verbose plus grid sounds off so might as well be obscure like just `r`
(hesitated with `g`, `tid`, `gid`, `rid`,.... naming is hard)