### PR TITLE
Allow caller code to use Colors directly without if 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,5 @@ When on console:
 ![Example console color output](color.png)
 
 JSON formatted logs can also be converted back to text later/after capture and similarly colorized using [fortio.org/logc](https://github.com/fortio/logc#logc)
+
+The `log.Colors` can be used by callers and they'll be empty string when not in color mode, and the ansi escape codes otherwise.

--- a/console_logging.go
+++ b/console_logging.go
@@ -41,7 +41,7 @@ var (
 	// these should really be constants but go doesn't have constant structs, arrays etc...
 
 	// ANSI color codes.
-	// These will be reset to empty string if color is disabled (see ColorMode and SetColorMode)
+	// These will be reset to empty string if color is disabled (see ColorMode and SetColorMode).
 	colors = color{
 		Reset:     "\033[0m",
 		Red:       "\033[31m",

--- a/console_logging.go
+++ b/console_logging.go
@@ -41,7 +41,8 @@ var (
 	// these should really be constants but go doesn't have constant structs, arrays etc...
 
 	// ANSI color codes.
-	Colors = color{
+	// These will be reset to empty string if color is disabled (see ColorMode and SetColorMode)
+	colors = color{
 		Reset:     "\033[0m",
 		Red:       "\033[31m",
 		Green:     "\033[32m",
@@ -54,6 +55,7 @@ var (
 		BrightRed: "\033[91m",
 		DarkGray:  "\033[90m",
 	}
+	Colors = colors
 
 	// Mapping of log levels to color.
 	LevelToColor = []string{
@@ -81,8 +83,15 @@ func ConsoleLogging() bool {
 
 // SetColorMode computes whether we currently should be using color text mode or not.
 // Need to be reset if config changes (but is already automatically re evaluated when calling SetOutput()).
+// It will reset the Colors variable to either be the actual escape sequences or empty strings (when
+// color is disabled).
 func SetColorMode() {
 	Color = ColorMode()
+	if Color {
+		Colors = colors
+	} else {
+		Colors = color{}
+	}
 }
 
 // ColorMode returns true if we should be using color text mode, which is either because it's

--- a/console_logging.go
+++ b/console_logging.go
@@ -41,8 +41,9 @@ var (
 	// these should really be constants but go doesn't have constant structs, arrays etc...
 
 	// ANSI color codes.
-	// These will be reset to empty string if color is disabled (see ColorMode and SetColorMode).
-	colors = color{
+	// This isn't meant to be used directly and is here only to document the names of the struct.
+	// Use the Colors variable instead.
+	ANSIColors = color{
 		Reset:     "\033[0m",
 		Red:       "\033[31m",
 		Green:     "\033[32m",
@@ -55,7 +56,11 @@ var (
 		BrightRed: "\033[91m",
 		DarkGray:  "\033[90m",
 	}
-	Colors = colors
+
+	// ANSI color codes or empty depending on ColorMode.
+	// These will be reset to empty string if color is disabled (see ColorMode() and SetColorMode()).
+	// Start with actual colors, will be reset to empty if color is disabled.
+	Colors = ANSIColors
 
 	// Mapping of log levels to color.
 	LevelToColor = []string{
@@ -88,7 +93,7 @@ func ConsoleLogging() bool {
 func SetColorMode() {
 	Color = ColorMode()
 	if Color {
-		Colors = colors
+		Colors = ANSIColors
 	} else {
 		Colors = color{}
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -161,7 +161,8 @@ func TestColorMode(t *testing.T) {
 	if Colors.Green == "" {
 		t.Errorf("expected to have green color not empty when in color mode")
 	}
-	// Reset for other/further tests
+	prevGreen := Colors.Green
+	// turn off color mode
 	Config.ForceColor = false
 	SetColorMode()
 	if Color {
@@ -170,6 +171,18 @@ func TestColorMode(t *testing.T) {
 	if Colors.Green != "" {
 		t.Errorf("expected to have green color empty when not color mode, got %q", Colors.Green)
 	}
+	// Show one can mutate/change/tweak colors
+	ANSIColors.Green = "foo"
+	Config.ForceColor = true
+	SetColorMode()
+	if Colors.Green != "foo" {
+		t.Errorf("expected to have green color preserved, got %q", Colors.Green)
+	}
+	// put it back to real green for other tests
+	ANSIColors.Green = prevGreen
+	// Reset for other/further tests
+	Config.ForceColor = false
+	SetColorMode()
 }
 
 func TestSetLevel(t *testing.T) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -158,8 +158,18 @@ func TestColorMode(t *testing.T) {
 	if cs == "" {
 		t.Errorf("got empty color timestamp")
 	}
+	if Colors.Green == "" {
+		t.Errorf("expected to have green color not empty when in color mode")
+	}
 	// Reset for other/further tests
 	Config.ForceColor = false
+	SetColorMode()
+	if Color {
+		t.Errorf("expected to not be in color mode after SetColorMode() and forcecolor false")
+	}
+	if Colors.Green != "" {
+		t.Errorf("expected to have green color empty when not color mode, got %q", Colors.Green)
+	}
 }
 
 func TestSetLevel(t *testing.T) {


### PR DESCRIPTION
and they'll get reset to empty string if color mode is disabled (and vice versa but back as escape codes if color mode is on)

