### PR TITLE
Recursive json serialization for structured attributes (log.Any)

### DIFF
--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -30,8 +30,8 @@ func TestLogRequest(t *testing.T) {
 	w.Flush()
 	actual := b.String()
 	//nolint: lll
-	expected := `{"level":"info","msg":"test1","method":"","url":"<nil>","proto":"","remote_addr":"","host":"foo-host:123","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":true,"tls.peer_cn":"x\nyz","header.foo":"bar1,bar2"}
-{"level":"info","msg":"test2","method":"","url":"<nil>","proto":"","remote_addr":"","host":"foo-host:123","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2"}
+	expected := `{"level":"info","msg":"test1","method":"","url":null,"proto":"","remote_addr":"","host":"foo-host:123","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":true,"tls.peer_cn":"x\nyz","header.foo":"bar1,bar2"}
+{"level":"info","msg":"test2","method":"","url":null,"proto":"","remote_addr":"","host":"foo-host:123","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2"}
 `
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)

--- a/logger.go
+++ b/logger.go
@@ -592,7 +592,7 @@ type ValueType[T ValueTypes] struct {
 func toJSON(v any) string {
 	bytes, err := json.Marshal(v)
 	if err != nil {
-		return fmt.Sprintf("ERR marshaling %v: %v", v, err)
+		return strconv.Quote(fmt.Sprintf("ERR marshaling %v: %v", v, err))
 	}
 	str := string(bytes)
 	// This is kinda hacky way to handle both structured and custom serialization errors, and

--- a/logger.go
+++ b/logger.go
@@ -25,6 +25,7 @@ package log // import "fortio.org/log"
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
@@ -32,7 +33,6 @@ import (
 	"math"
 	"os"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -589,6 +589,7 @@ type ValueType[T ValueTypes] struct {
 	Val T
 }
 
+/*
 func arrayToString(s []interface{}) string {
 	var buf strings.Builder
 	buf.WriteString("[")
@@ -623,19 +624,30 @@ func mapToString(s map[string]interface{}) string {
 	buf.WriteString("}")
 	return buf.String()
 }
+*/
+
+func toJSON[T ValueTypes](v T) string {
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("ERR marshaling %v: %v", v, err)
+	}
+	return string(bytes)
+}
 
 func (v ValueType[T]) String() string {
 	// if the type is numeric, use Sprint(v.val) otherwise use Sprintf("%q", v.Val) to quote it.
-	switch s := any(v.Val).(type) {
+	switch /*s :=*/ any(v.Val).(type) {
 	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
 		float32, float64:
 		return fmt.Sprint(v.Val)
+	/* It's all handled by json fallback now - todo test if this is/was cheaper?
 	case []interface{}:
 		return arrayToString(s)
 	case map[string]interface{}:
 		return mapToString(s)
+	*/
 	default:
-		return fmt.Sprintf("%q", fmt.Sprint(v.Val))
+		return toJSON(v.Val) // was fmt.Sprintf("%q", fmt.Sprint(v.Val))
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -627,13 +627,6 @@ func mapToString(s map[string]interface{}) string {
 */
 
 func toJSON(v any) string {
-	e, isError := v.(error) // Remember and cast only once if this is an error type or not
-	if isError {
-		// Check for nil explicitly if v is an error
-		if e == nil {
-			return "null"
-		}
-	}
 	bytes, err := json.Marshal(v)
 	if err != nil {
 		return fmt.Sprintf("ERR marshaling %v: %v", v, err)
@@ -641,7 +634,7 @@ func toJSON(v any) string {
 	str := string(bytes)
 	// This is kinda hacky way to handle both structured and custom serialization errors, and
 	// struct with no public fields for which we need to call Error() to get a useful string.
-	if isError && str == "{}" {
+	if e, isError := v.(error); isError && str == "{}" {
 		return fmt.Sprintf("%q", e.Error())
 	}
 	return str

--- a/logger.go
+++ b/logger.go
@@ -636,10 +636,12 @@ func toJSON[T ValueTypes](v T) string {
 
 func (v ValueType[T]) String() string {
 	// if the type is numeric, use Sprint(v.val) otherwise use Sprintf("%q", v.Val) to quote it.
-	switch /*s :=*/ any(v.Val).(type) {
+	switch s := any(v.Val).(type) {
 	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
 		float32, float64:
 		return fmt.Sprint(v.Val)
+	case error: // struct with no public fields so we need to call Error() to get a string. otherwise we get {}
+		return fmt.Sprintf("%q", s.Error())
 	/* It's all handled by json fallback now - todo test if this is/was cheaper?
 	case []interface{}:
 		return arrayToString(s)

--- a/logger.go
+++ b/logger.go
@@ -589,43 +589,6 @@ type ValueType[T ValueTypes] struct {
 	Val T
 }
 
-/*
-func arrayToString(s []interface{}) string {
-	var buf strings.Builder
-	buf.WriteString("[")
-	for i, e := range s {
-		if i != 0 {
-			buf.WriteString(",")
-		}
-		vv := ValueType[interface{}]{Val: e}
-		buf.WriteString(vv.String())
-	}
-	buf.WriteString("]")
-	return buf.String()
-}
-
-func mapToString(s map[string]interface{}) string {
-	var buf strings.Builder
-	buf.WriteString("{")
-	keys := make([]string, 0, len(s))
-	for k := range s {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for i, k := range keys {
-		if i != 0 {
-			buf.WriteString(",")
-		}
-		buf.WriteString(fmt.Sprintf("%q", k))
-		buf.WriteString(":")
-		vv := ValueType[interface{}]{Val: s[k]}
-		buf.WriteString(vv.String())
-	}
-	buf.WriteString("}")
-	return buf.String()
-}
-*/
-
 func toJSON(v any) string {
 	bytes, err := json.Marshal(v)
 	if err != nil {
@@ -642,18 +605,13 @@ func toJSON(v any) string {
 
 func (v ValueType[T]) String() string {
 	// if the type is numeric, use Sprint(v.val) otherwise use Sprintf("%q", v.Val) to quote it.
-	switch /*s :=*/ any(v.Val).(type) {
+	switch s := any(v.Val).(type) {
 	case bool, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64,
 		float32, float64:
-		return fmt.Sprint(v.Val)
-	/* It's all handled by json fallback now - todo test if this is/was cheaper?
-	case error: // struct with no public fields so we need to call Error() to get a string. otherwise we get {}
-		return fmt.Sprintf("%q", s.Error())
-	case []interface{}:
-		return arrayToString(s)
-	case map[string]interface{}:
-		return mapToString(s)
-	*/
+		return fmt.Sprint(s)
+	case string:
+		return fmt.Sprintf("%q", s)
+	/* It's all handled by json fallback now even though slightly more expensive at runtime, it's a lot simpler */
 	default:
 		return toJSON(v.Val) // was fmt.Sprintf("%q", fmt.Sprint(v.Val))
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -752,13 +752,36 @@ func TestNoLevel(t *testing.T) {
 	}
 }
 
+type customError struct {
+	Msg  string
+	Code int
+}
+
+func (e customError) Error() string {
+	return fmt.Sprintf("custom error %s (code %d)", e.Msg, e.Code)
+}
+
 func TestSerializationOfError(t *testing.T) {
-	err := fmt.Errorf("test error")
-	Errf("Error on purpose: %v", err)
-	S(Error, "Error on purpose", Any("err", err))
+	var err error
 	kv := Any("err", err)
 	kvStr := kv.StringValue()
-	expected := `"test error"`
+	expected := `null`
+	if kvStr != expected {
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", kvStr, expected)
+	}
+	err = fmt.Errorf("test error")
+	Errf("Error on purpose: %v", err)
+	S(Error, "Error on purpose", Any("err", err))
+	kv = Any("err", err)
+	kvStr = kv.StringValue()
+	expected = `"test error"`
+	if kvStr != expected {
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", kvStr, expected)
+	}
+	err = customError{Msg: "custom error", Code: 42}
+	kv = Any("err", err)
+	kvStr = kv.StringValue()
+	expected = `{"Msg":"custom error","Code":42}`
 	if kvStr != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", kvStr, expected)
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -787,6 +787,17 @@ func TestSerializationOfError(t *testing.T) {
 	}
 }
 
+func TestToJSON_MarshalError(t *testing.T) {
+	badValue := make(chan int)
+
+	expected := fmt.Sprintf("\"ERR marshaling %v: %v\"", badValue, "json: unsupported type: chan int")
+	actual := toJSON(badValue)
+
+	if actual != expected {
+		t.Errorf("Expected %q, got %q", expected, actual)
+	}
+}
+
 // io.Discard but specially known to by logger optimizations for instance.
 type discard struct{}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -752,6 +752,18 @@ func TestNoLevel(t *testing.T) {
 	}
 }
 
+func TestSerializationOfError(t *testing.T) {
+	err := fmt.Errorf("test error")
+	Errf("Error on purpose: %v", err)
+	S(Error, "Error on purpose", Any("err", err))
+	kv := Any("err", err)
+	kvStr := kv.StringValue()
+	expected := `"test error"`
+	if kvStr != expected {
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", kvStr, expected)
+	}
+}
+
 // io.Discard but specially known to by logger optimizations for instance.
 type discard struct{}
 


### PR DESCRIPTION
Recursive json serialization for structured attributes (log.Any) and also:
- Handles both errors with exported struct fields (as sub objects) and the ones who do not (calling .Error() to get the JSON string)
- Correctly handles nil as JSON null

Of note: performance is somewhat worse