### PR TITLE
Http response recording/logging + Environment variables based config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters-settings:
         allow:
           - $gostd
           - fortio.org/log
+          - fortio.org/struct2env
   lll:
     # max line length, lines longer will be reported. Default is 120.
     # '\t' is counted as 1 character by default, and can be changed with the tab-width option

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ The `log.Colors` can be used by callers and they'll be empty string when not in 
 
 `LogAndCall()` combines `LogRequest` and `LogResponse` for a light middleware recording what happens during serving of a request (both incoming and outgoing attributes).
 
-For instance (most attributes elided for brievety, also logs client cert and TLSInfo if applicable)
+For instance (most attributes elided for brevity, also logs client cert and TLSInfo if applicable)
 ```json
-{"level":"info","msg":"test-log-and-call2","method":"GET","url":{"Path":"/tea"},"status":418,"size":5,"microsec":100042}
+{"level":"info","msg":"test-log-and-call2","method":"GET","url":"/tea","status":418,"size":5,"microsec":100042}
 ```
 
 # Config

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For instance (most attributes elided for brievety, also logs client cert and TLS
 
 You can either use `fortio.org/cli` or `fortio.org/scli` (or `dflags`) for configuration using flags (or dynamic flags and config map) or use the environment variables:
 
-```
+```bash
 LOGGER_LOG_PREFIX=' '
 LOGGER_LOG_FILE_AND_LINE=false
 LOGGER_FATAL_PANICS=false
@@ -97,6 +97,6 @@ LOGGER_NO_TIMESTAMP=false
 LOGGER_CONSOLE_COLOR=true
 LOGGER_FORCE_COLOR=false
 LOGGER_GOROUTINE_ID=false
-LOGGER_COMBINE_REQUEST_AND_RESPONSE=false
+LOGGER_COMBINE_REQUEST_AND_RESPONSE=true
 LOGGER_LEVEL='Info'
 ```

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ JSON formatted logs can also be converted back to text later/after capture and s
 
 The `log.Colors` can be used by callers and they'll be empty string when not in color mode, and the ansi escape codes otherwise.
 
+# HTTP request/response logging
+
+`LogAndCall()` combines `LogRequest` and `LogResponse` for a light middleware recording what happens during serving of a request (both incoming and outgoing attributes).
+
+For instance (most attributes elided for brievety, also logs client cert and TLSInfo if applicable)
+```json
+{"level":"info","msg":"test-log-and-call2","method":"GET","url":{"Path":"/tea"},"status":418,"size":5,"microsec":100042}
+```
+
 # Config
 
 You can either use `fortio.org/cli` or `fortio.org/scli` (or `dflags`) for configuration using flags (or dynamic flags and config map) or use the environment variables:

--- a/README.md
+++ b/README.md
@@ -74,3 +74,20 @@ When on console:
 JSON formatted logs can also be converted back to text later/after capture and similarly colorized using [fortio.org/logc](https://github.com/fortio/logc#logc)
 
 The `log.Colors` can be used by callers and they'll be empty string when not in color mode, and the ansi escape codes otherwise.
+
+# Config
+
+You can either use `fortio.org/cli` or `fortio.org/scli` (or `dflags`) for configuration using flags (or dynamic flags and config map) or use the environment variables:
+
+```
+LOGGER_LOG_PREFIX=' '
+LOGGER_LOG_FILE_AND_LINE=false
+LOGGER_FATAL_PANICS=false
+LOGGER_JSON=false
+LOGGER_NO_TIMESTAMP=false
+LOGGER_CONSOLE_COLOR=true
+LOGGER_FORCE_COLOR=false
+LOGGER_GOROUTINE_ID=false
+LOGGER_COMBINE_REQUEST_AND_RESPONSE=false
+LOGGER_LEVEL='Info'
+```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module fortio.org/log
 
 go 1.18
+
+require fortio.org/struct2env v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+fortio.org/struct2env v0.4.0 h1:k5alSOTf3YHiB3MuacjDHQ3YhVWvNZ95ZP/a6MqvyLo=
+fortio.org/struct2env v0.4.0/go.mod h1:lENUe70UwA1zDUCX+8AsO663QCFqYaprk5lnPhjD410=

--- a/http_logging.go
+++ b/http_logging.go
@@ -94,7 +94,11 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 		}
 		sort.Strings(keys)
 		for _, name := range keys {
-			attr = append(attr, Str("header."+name, strings.Join(r.Header[name], ",")))
+			nl := strings.ToLower(name)
+			if nl != "user-agent" {
+				nl = "header." + nl
+			}
+			attr = append(attr, Str(nl, strings.Join(r.Header[name], ",")))
 		}
 	}
 	S(Info, msg, attr...)

--- a/http_logging.go
+++ b/http_logging.go
@@ -131,6 +131,9 @@ func (rr *ResponseRecorder) WriteHeader(code int) {
 
 // LogResponse logs the response code, byte size and duration of the request.
 // additional key:value pairs can be passed as extraAttributes.
+// If Config.CombineRequestAndResponse or the LOGGER_COMBINE_REQUEST_AND_RESPONSE
+// environment variable is true. then a single log entry is done combining request and
+// response information, including catching for panic
 //
 //nolint:revive // name is fine.
 func LogAndCall(msg string, hf http.HandlerFunc, extraAttributes ...KeyVal) http.HandlerFunc {

--- a/http_logging.go
+++ b/http_logging.go
@@ -83,18 +83,19 @@ func LogResponse[T *ResponseRecorder | *http.Response](r T, msg string, extraAtt
 	if !Log(Info) {
 		return
 	}
-	var attr []KeyVal
-	switch v := any(r).(type) {
+	var status int
+	var size int64
+	switch v := any(r).(type) { // go generics...
 	case *ResponseRecorder:
-		attr = []KeyVal{
-			Int("status", v.StatusCode),
-			Int64("size", v.ContentLength),
-		}
+		status = v.StatusCode
+		size = v.ContentLength
 	case *http.Response:
-		attr = []KeyVal{
-			Int("status", v.StatusCode),
-			Int64("size", v.ContentLength),
-		}
+		status = v.StatusCode
+		size = v.ContentLength
+	}
+	attr := []KeyVal{
+		Int("status", status),
+		Int64("size", size),
 	}
 	attr = append(attr, extraAttributes...)
 	S(Info, msg, attr...)

--- a/http_logging.go
+++ b/http_logging.go
@@ -136,6 +136,13 @@ func (rr *ResponseRecorder) WriteHeader(code int) {
 	rr.StatusCode = code
 }
 
+// Implement http.Flusher interface
+func (rr *ResponseRecorder) Flush() {
+	if f, ok := rr.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // LogAndCall logs the incoming request and the response code, byte size and duration
 // of the request.
 //

--- a/http_logging.go
+++ b/http_logging.go
@@ -129,11 +129,14 @@ func (rr *ResponseRecorder) WriteHeader(code int) {
 	rr.StatusCode = code
 }
 
-// LogResponse logs the response code, byte size and duration of the request.
-// additional key:value pairs can be passed as extraAttributes.
+// LogAndCall logs the incoming request and the response code, byte size and duration
+// of the request.
+//
 // If Config.CombineRequestAndResponse or the LOGGER_COMBINE_REQUEST_AND_RESPONSE
 // environment variable is true. then a single log entry is done combining request and
-// response information, including catching for panic
+// response information, including catching for panic.
+//
+// Additional key:value pairs can be passed as extraAttributes.
 //
 //nolint:revive // name is fine.
 func LogAndCall(msg string, hf http.HandlerFunc, extraAttributes ...KeyVal) http.HandlerFunc {

--- a/http_logging.go
+++ b/http_logging.go
@@ -57,8 +57,15 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 	if !Log(Info) {
 		return
 	}
+	// URL struct is quite verbose and not that interesting to log all pieces so we log the String() version
+	var url KeyVal
+	if r.URL == nil {
+		url = Any("url", r.URL) // basically 'null'
+	} else {
+		url = Str("url", r.URL.String())
+	}
 	attr := []KeyVal{
-		Str("method", r.Method), Attr("url", r.URL), Str("proto", r.Proto),
+		Str("method", r.Method), url, Str("proto", r.Proto),
 		Str("remote_addr", r.RemoteAddr), Str("host", r.Host),
 		Str("header.x-forwarded-proto", r.Header.Get("X-Forwarded-Proto")),
 		Str("header.x-forwarded-for", r.Header.Get("X-Forwarded-For")),

--- a/http_logging.go
+++ b/http_logging.go
@@ -69,6 +69,7 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 		Str("remote_addr", r.RemoteAddr), Str("host", r.Host),
 		Str("header.x-forwarded-proto", r.Header.Get("X-Forwarded-Proto")),
 		Str("header.x-forwarded-for", r.Header.Get("X-Forwarded-For")),
+		Str("header.x-forwarded-host", r.Header.Get("X-Forwarded-Host")),
 		Str("user-agent", r.Header.Get("User-Agent")),
 	}
 	attr = AppendTLSInfoAttrs(attr, r)

--- a/http_logging.go
+++ b/http_logging.go
@@ -88,7 +88,7 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 		// Host is removed from headers map and put separately
 		// Need to sort to get a consistent order
 		keys := make([]string, 0, len(r.Header))
-		for name, _ := range r.Header {
+		for name := range r.Header {
 			keys = append(keys, strings.ToLower(name))
 		}
 		sort.Strings(keys)
@@ -153,7 +153,7 @@ func (rr *ResponseRecorder) WriteHeader(code int) {
 	rr.StatusCode = code
 }
 
-// Implement http.Flusher interface
+// Implement http.Flusher interface.
 func (rr *ResponseRecorder) Flush() {
 	if f, ok := rr.w.(http.Flusher); ok {
 		f.Flush()

--- a/http_logging.go
+++ b/http_logging.go
@@ -75,9 +75,10 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 	attr := []KeyVal{
 		Str("method", r.Method), url, Str("host", r.Host),
 		Str("proto", r.Proto), Str("remote_addr", r.RemoteAddr),
-		Str("user-agent", r.Header.Get("User-Agent")),
 	}
 	if !LogVerbose() { // in verbose all headers are already logged
+		attr = AddIfNotEmpty(attr, "user-agent", r.Header.Get("User-Agent"))
+		// note this only prints the first one, while verbose mode will join all values with ','
 		attr = AddIfNotEmpty(attr, "header.x-forwarded-proto", r.Header.Get("X-Forwarded-Proto"))
 		attr = AddIfNotEmpty(attr, "header.x-forwarded-for", r.Header.Get("X-Forwarded-For"))
 		attr = AddIfNotEmpty(attr, "header.x-forwarded-host", r.Header.Get("X-Forwarded-Host"))
@@ -89,7 +90,7 @@ func LogRequest(r *http.Request, msg string, extraAttributes ...KeyVal) {
 		// Need to sort to get a consistent order
 		keys := make([]string, 0, len(r.Header))
 		for name := range r.Header {
-			keys = append(keys, strings.ToLower(name))
+			keys = append(keys, name)
 		}
 		sort.Strings(keys)
 		for _, name := range keys {

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -76,7 +76,7 @@ func (n *NullHTTPWriter) Flush() {
 func (n *NullHTTPWriter) WriteHeader(_ int) {}
 
 func TestLogAndCall(t *testing.T) {
-	Config.LogFileAndLine = false
+	Config.LogFileAndLine = true // yet won't show up in output
 	Config.JSON = true
 	Config.NoTimestamp = true
 	Config.CombineRequestAndResponse = false // Separate request and response logging
@@ -122,6 +122,7 @@ func TestLogAndCall(t *testing.T) {
 	}
 	n.doPanic = true
 	n.doErr = false
+	SetLogLevelQuiet(Verbose)
 	b.Reset()
 	LogAndCall("test-log-and-call4", testHandler).ServeHTTP(hw, hr)
 	w.Flush()

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -50,20 +50,20 @@ func testHandler(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("hello"))
 }
 
-type NullHttpWriter struct{ doErr bool }
+type NullHTTPWriter struct{ doErr bool }
 
-func (n *NullHttpWriter) Header() http.Header {
+func (n *NullHTTPWriter) Header() http.Header {
 	return nil
 }
 
-func (n *NullHttpWriter) Write(b []byte) (int, error) {
+func (n *NullHTTPWriter) Write(b []byte) (int, error) {
 	if n.doErr {
 		return 0, fmt.Errorf("some fake http write error")
 	}
 	return len(b), nil
 }
 
-func (n *NullHttpWriter) WriteHeader(_ int) {}
+func (n *NullHTTPWriter) WriteHeader(_ int) {}
 
 func TestLogAndCall(t *testing.T) {
 	Config.LogFileAndLine = false
@@ -73,7 +73,7 @@ func TestLogAndCall(t *testing.T) {
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
 	hr := &http.Request{}
-	n := &NullHttpWriter{}
+	n := &NullHTTPWriter{}
 	hw := &ResponseRecorder{w: n}
 	LogAndCall("test-log-and-call", testHandler).ServeHTTP(hw, hr)
 	w.Flush()

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -24,7 +24,7 @@ func TestLogRequest(t *testing.T) {
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
-	h := http.Header{"FoO": []string{"bar1", "bar2"}, "X-Forwarded-Host": []string{"foo.fortio.org"}}
+	h := http.Header{"FoO": []string{"bar1", "bar2"}, "X-Forwarded-Host": []string{"fOO.fortio.org"}}
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "x\nyz"}} // make sure special chars are escaped
 	r := &http.Request{TLS: &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}, Header: h, Host: "foo-host:123"}
 	LogRequest(r, "test1")
@@ -34,7 +34,7 @@ func TestLogRequest(t *testing.T) {
 	w.Flush()
 	actual := b.String()
 	//nolint: lll
-	expected := `{"level":"info","msg":"test1","method":"","url":null,"host":"foo-host:123","proto":"","remote_addr":"","tls":true,"tls.peer_cn":"x\nyz","header.FoO":"bar1,bar2","header.X-Forwarded-Host":"foo.fortio.org"}
+	expected := `{"level":"info","msg":"test1","method":"","url":null,"host":"foo-host:123","proto":"","remote_addr":"","tls":true,"tls.peer_cn":"x\nyz","header.foo":"bar1,bar2","header.x-forwarded-host":"fOO.fortio.org"}
 {"level":"info","msg":"test2","method":"","url":null,"host":"foo-host:123","proto":"","remote_addr":"","extra1":"v1","extra2":"v2"}
 `
 	if actual != expected {

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -69,6 +69,10 @@ func (n *NullHTTPWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
+// Also implement http.Flusher interface
+func (n *NullHTTPWriter) Flush() {
+}
+
 func (n *NullHTTPWriter) WriteHeader(_ int) {}
 
 func TestLogAndCall(t *testing.T) {
@@ -130,6 +134,13 @@ func TestLogAndCall(t *testing.T) {
 	}
 	// restore for other tests
 	Config.GoroutineID = true
+	// check for flusher interface
+	var hwi http.ResponseWriter = hw
+	flusher, ok := hwi.(http.Flusher)
+	if !ok {
+		t.Fatalf("expected http.ResponseWriter to be an http.Flusher")
+	}
+	flusher.Flush()
 }
 
 func TestLogResponseOnHTTPResponse(t *testing.T) {

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -75,7 +75,7 @@ func TestLogAndCall(t *testing.T) {
 	Config.LogFileAndLine = false
 	Config.JSON = true
 	Config.NoTimestamp = true
-	Config.CombineRequestAndResponse = false // single line test
+	Config.CombineRequestAndResponse = false // Separate request and response logging
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
@@ -96,7 +96,7 @@ func TestLogAndCall(t *testing.T) {
 	}
 	hr.URL = &url.URL{Path: "/tea"}
 	b.Reset()
-	Config.CombineRequestAndResponse = true // single line test
+	Config.CombineRequestAndResponse = true // Combined logging test
 	LogAndCall("test-log-and-call2", testHandler).ServeHTTP(hw, hr)
 	w.Flush()
 	actual = b.String()

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -75,6 +75,7 @@ func TestLogAndCall(t *testing.T) {
 	Config.LogFileAndLine = false
 	Config.JSON = true
 	Config.NoTimestamp = true
+	Config.CombineRequestAndResponse = false // single line test
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -101,7 +101,7 @@ func TestLogAndCall(t *testing.T) {
 	w.Flush()
 	actual = b.String()
 	//nolint: lll
-	expectedPrefix = `{"level":"info","msg":"test-log-and-call2","method":"","url":{"Scheme":"","Opaque":"","User":null,"Host":"","Path":"/tea","RawPath":"","OmitHost":false,"ForceQuery":false,"RawQuery":"","Fragment":"","RawFragment":""},"proto":"","remote_addr":"","host":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","status":418,"size":5,"microsec":1`
+	expectedPrefix = `{"level":"info","msg":"test-log-and-call2","method":"","url":"/tea","proto":"","remote_addr":"","host":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","status":418,"size":5,"microsec":1`
 	if !strings.HasPrefix(actual, expectedPrefix) {
 		t.Errorf("unexpected:\n%s\nvs should start with:\n%s\n", actual, expectedPrefix)
 	}

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -69,7 +69,7 @@ func (n *NullHTTPWriter) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// Also implement http.Flusher interface
+// Also implement http.Flusher interface.
 func (n *NullHTTPWriter) Flush() {
 }
 

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -17,14 +17,14 @@ import (
 
 // There is additional functional testing in fortio.org/fortio/fhttp.
 func TestLogRequest(t *testing.T) {
-	SetLogLevel(Verbose) // make sure it's already debug when we capture
+	SetLogLevel(Verbose) // make sure it's already verbose when we capture
 	Config.LogFileAndLine = false
 	Config.JSON = true
 	Config.NoTimestamp = true
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
-	h := http.Header{"foo": []string{"bar1", "bar2"}}
+	h := http.Header{"foo": []string{"bar1", "bar2"}, "X-Forwarded-Host": []string{"foo.fortio.org"}}
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "x\nyz"}} // make sure special chars are escaped
 	r := &http.Request{TLS: &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}, Header: h, Host: "foo-host:123"}
 	LogRequest(r, "test1")
@@ -34,8 +34,8 @@ func TestLogRequest(t *testing.T) {
 	w.Flush()
 	actual := b.String()
 	//nolint: lll
-	expected := `{"level":"info","msg":"test1","method":"","url":null,"proto":"","remote_addr":"","host":"foo-host:123","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","tls":true,"tls.peer_cn":"x\nyz","header.foo":"bar1,bar2"}
-{"level":"info","msg":"test2","method":"","url":null,"proto":"","remote_addr":"","host":"foo-host:123","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","extra1":"v1","extra2":"v2"}
+	expected := `{"level":"info","msg":"test1","method":"","url":null,"host":"foo-host:123","proto":"","remote_addr":"","user-agent":"","tls":true,"tls.peer_cn":"x\nyz","header.foo":"bar1,bar2","header.x-forwarded-host":""}
+{"level":"info","msg":"test2","method":"","url":null,"host":"foo-host:123","proto":"","remote_addr":"","user-agent":"","extra1":"v1","extra2":"v2"}
 `
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
@@ -80,17 +80,19 @@ func TestLogAndCall(t *testing.T) {
 	Config.JSON = true
 	Config.NoTimestamp = true
 	Config.CombineRequestAndResponse = false // Separate request and response logging
+	SetLogLevelQuiet(Info)
 	var b bytes.Buffer
 	w := bufio.NewWriter(&b)
 	SetOutput(w)
 	hr := &http.Request{}
+	hr.Header = http.Header{"foo": []string{"bar1", "bar2"}, "X-Forwarded-Host": []string{"foo2.fortio.org"}}
 	n := &NullHTTPWriter{}
 	hw := &ResponseRecorder{w: n}
 	LogAndCall("test-log-and-call", testHandler).ServeHTTP(hw, hr)
 	w.Flush()
 	actual := b.String()
 	//nolint: lll
-	expectedPrefix := `{"level":"info","msg":"test-log-and-call","method":"","url":null,"proto":"","remote_addr":"","host":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":""}
+	expectedPrefix := `{"level":"info","msg":"test-log-and-call","method":"","url":null,"host":"","proto":"","remote_addr":"","user-agent":"","header.x-forwarded-host":"foo2.fortio.org"}
 {"level":"info","msg":"test-log-and-call","status":200,"size":5,"microsec":1` // the 1 is for the 100ms sleep
 	if !strings.HasPrefix(actual, expectedPrefix) {
 		t.Errorf("unexpected:\n%s\nvs should start with:\n%s\n", actual, expectedPrefix)
@@ -105,7 +107,7 @@ func TestLogAndCall(t *testing.T) {
 	w.Flush()
 	actual = b.String()
 	//nolint: lll
-	expectedPrefix = `{"level":"info","msg":"test-log-and-call2","method":"","url":"/tea","proto":"","remote_addr":"","host":"","header.x-forwarded-proto":"","header.x-forwarded-for":"","user-agent":"","status":418,"size":5,"microsec":1`
+	expectedPrefix = `{"level":"info","msg":"test-log-and-call2","method":"","url":"/tea","host":"","proto":"","remote_addr":"","user-agent":"","header.x-forwarded-host":"foo2.fortio.org","status":418,"size":5,"microsec":10`
 	if !strings.HasPrefix(actual, expectedPrefix) {
 		t.Errorf("unexpected:\n%s\nvs should start with:\n%s\n", actual, expectedPrefix)
 	}
@@ -114,7 +116,7 @@ func TestLogAndCall(t *testing.T) {
 	LogAndCall("test-log-and-call3", testHandler).ServeHTTP(hw, hr)
 	w.Flush()
 	actual = b.String()
-	expectedFragment := `"user-agent":"","status":500,"size":0,"microsec":1`
+	expectedFragment := `"user-agent":"","header.x-forwarded-host":"foo2.fortio.org","status":500,"size":0,"microsec":1`
 	if !strings.Contains(actual, expectedFragment) {
 		t.Errorf("unexpected:\n%s\nvs should contain error:\n%s\n", actual, expectedFragment)
 	}

--- a/http_logging_test.go
+++ b/http_logging_test.go
@@ -127,6 +127,8 @@ func TestLogAndCall(t *testing.T) {
 	if !strings.Contains(actual, `{"level":"crit","msg":"panic in handler","error":"some fake http write panic"`) {
 		t.Errorf("unexpected:\n%s\nvs should contain error:\n%s\n", actual, "some fake http write panic")
 	}
+	// restore for other tests
+	Config.GoroutineID = true
 }
 
 func TestLogResponseOnHTTPResponse(t *testing.T) {

--- a/logger.go
+++ b/logger.go
@@ -57,8 +57,8 @@ const (
 	Critical
 	Fatal
 	NoLevel
-	// Prefix for all config from environment, eg
-	// e.g NoTimestamp becomes LOGGER_NO_TIMESTAMP
+	// Prefix for all config from environment,
+	// e.g NoTimestamp becomes LOGGER_NO_TIMESTAMP.
 	EnvPrefix = "LOGGER_"
 )
 

--- a/logger.go
+++ b/logger.go
@@ -188,8 +188,12 @@ func init() {
 		JSONStringLevelToLevel[name[1:len(name)-1]] = Level(l)
 	}
 	log.SetFlags(log.Ltime)
+	configFromEnv()
 	SetColorMode()
 	jWriter.buf.Grow(2048)
+}
+
+func configFromEnv() {
 	prev := Config.Level
 	struct2env.SetFromEnv(EnvPrefix, Config)
 	if Config.Level != "" && Config.Level != prev {
@@ -317,10 +321,7 @@ func setLogLevel(lvl Level, logChange bool) Level {
 // LOGGER_FORCE_COLOR, LOGGER_GOROUTINE_ID, LOGGER_COMBINE_REQUEST_AND_RESPONSE,
 // LOGGER_LEVEL.
 func EnvHelp(w io.Writer) {
-	res, err := struct2env.StructToEnvVars(Config)
-	if err != nil {
-		Errf("Error converting config to env: %v", err)
-	}
+	res, _ := struct2env.StructToEnvVars(Config)
 	str := struct2env.ToShellWithPrefix(EnvPrefix, res, true)
 	fmt.Fprint(w, str)
 }

--- a/logger.go
+++ b/logger.go
@@ -89,13 +89,14 @@ type LogConfig struct {
 // Use SetDefaultsForClientTools for CLIs.
 func DefaultConfig() *LogConfig {
 	return &LogConfig{
-		LogPrefix:      "> ",
-		LogFileAndLine: true,
-		FatalPanics:    true,
-		FatalExit:      os.Exit,
-		JSON:           true,
-		ConsoleColor:   true,
-		GoroutineID:    true,
+		LogPrefix:                 "> ",
+		LogFileAndLine:            true,
+		FatalPanics:               true,
+		FatalExit:                 os.Exit,
+		JSON:                      true,
+		ConsoleColor:              true,
+		GoroutineID:               true,
+		CombineRequestAndResponse: true,
 	}
 }
 
@@ -142,6 +143,7 @@ func SetDefaultsForClientTools() {
 	Config.ConsoleColor = true
 	Config.JSON = false
 	Config.GoroutineID = false
+	Config.CombineRequestAndResponse = false
 	SetColorMode()
 }
 

--- a/logger.go
+++ b/logger.go
@@ -323,6 +323,7 @@ func setLogLevel(lvl Level, logChange bool) Level {
 func EnvHelp(w io.Writer) {
 	res, _ := struct2env.StructToEnvVars(Config)
 	str := struct2env.ToShellWithPrefix(EnvPrefix, res, true)
+	fmt.Fprintln(w, "# Logger environment variables:")
 	fmt.Fprint(w, str)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -308,6 +308,12 @@ func setLogLevel(lvl Level, logChange bool) Level {
 	return prev
 }
 
+// EnvHelp shows the current config as environment variables.
+//
+// LOGGER_LOG_PREFIX, LOGGER_LOG_FILE_AND_LINE, LOGGER_FATAL_PANICS,
+// LOGGER_JSON, LOGGER_NO_TIMESTAMP, LOGGER_CONSOLE_COLOR, LOGGER_CONSOLE_COLOR
+// LOGGER_FORCE_COLOR, LOGGER_GOROUTINE_ID, LOGGER_COMBINE_REQUEST_AND_RESPONSE,
+// LOGGER_LEVEL.
 func EnvHelp(w io.Writer) {
 	res, err := struct2env.StructToEnvVars(Config)
 	if err != nil {

--- a/logger_test.go
+++ b/logger_test.go
@@ -798,6 +798,31 @@ func TestToJSON_MarshalError(t *testing.T) {
 	}
 }
 
+func TestEnvHelp(t *testing.T) {
+	SetDefaultsForClientTools()
+	Config.NoTimestamp = false
+	// Setup
+	var b bytes.Buffer
+	w := bufio.NewWriter(&b)
+	EnvHelp(w)
+	w.Flush()
+	actual := b.String()
+	expected := `LOGGER_LOG_PREFIX=' '
+LOGGER_LOG_FILE_AND_LINE=false
+LOGGER_FATAL_PANICS=false
+LOGGER_JSON=false
+LOGGER_NO_TIMESTAMP=false
+LOGGER_CONSOLE_COLOR=true
+LOGGER_FORCE_COLOR=false
+LOGGER_GOROUTINE_ID=false
+LOGGER_COMBINE_REQUEST_AND_RESPONSE=false
+LOGGER_LEVEL='Info'
+`
+	if actual != expected {
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
+	}
+}
+
 // io.Discard but specially known to by logger optimizations for instance.
 type discard struct{}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -824,7 +824,7 @@ LOGGER_LEVEL='Info'
 }
 
 func TestConfigFromEnvError(t *testing.T) {
-	os.Setenv("LOGGER_LEVEL", "foo")
+	t.Setenv("LOGGER_LEVEL", "foo")
 	var buf bytes.Buffer
 	SetOutput(&buf)
 	configFromEnv()
@@ -836,7 +836,7 @@ func TestConfigFromEnvError(t *testing.T) {
 }
 
 func TestConfigFromEnvOk(t *testing.T) {
-	os.Setenv("LOGGER_LEVEL", "verbose")
+	t.Setenv("LOGGER_LEVEL", "verbose")
 	var buf bytes.Buffer
 	SetOutput(&buf)
 	configFromEnv()

--- a/logger_test.go
+++ b/logger_test.go
@@ -823,6 +823,30 @@ LOGGER_LEVEL='Info'
 	}
 }
 
+func TestConfigFromEnvError(t *testing.T) {
+	os.Setenv("LOGGER_LEVEL", "foo")
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	configFromEnv()
+	actual := buf.String()
+	expected := "Invalid log level from environment"
+	if !strings.Contains(actual, expected) {
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
+	}
+}
+
+func TestConfigFromEnvOk(t *testing.T) {
+	os.Setenv("LOGGER_LEVEL", "verbose")
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	configFromEnv()
+	actual := buf.String()
+	expected := "Log level set from environment LOGGER_LEVEL to Verbose"
+	if !strings.Contains(actual, expected) {
+		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
+	}
+}
+
 // io.Discard but specially known to by logger optimizations for instance.
 type discard struct{}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -807,7 +807,8 @@ func TestEnvHelp(t *testing.T) {
 	EnvHelp(w)
 	w.Flush()
 	actual := b.String()
-	expected := `LOGGER_LOG_PREFIX=' '
+	expected := `# Logger environment variables:
+LOGGER_LOG_PREFIX=' '
 LOGGER_LOG_FILE_AND_LINE=false
 LOGGER_FATAL_PANICS=false
 LOGGER_JSON=false


### PR DESCRIPTION
See README.md and tests for new `LogAndCall()`

For env based config, you can set (see EnvHelp for list/current values):

```
LOGGER_LOG_PREFIX=' '
LOGGER_LOG_FILE_AND_LINE=false
LOGGER_FATAL_PANICS=false
LOGGER_JSON=false
LOGGER_NO_TIMESTAMP=false
LOGGER_CONSOLE_COLOR=true
LOGGER_FORCE_COLOR=false
LOGGER_GOROUTINE_ID=false
LOGGER_COMBINE_REQUEST_AND_RESPONSE=false
LOGGER_LEVEL='Info'
```