### PR TITLE
Handle errors printing like slog json marshaller

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -653,7 +653,8 @@ func (v ValueType[T]) String() string {
 	case error:
 		// Sadly structured errors like nettwork error don't have the reason in
 		// the exposed struct/JSON - ie on gets
-		// {"Op":"read","Net":"tcp","Source":{"IP":"127.0.0.1","Port":60067,"Zone":""},"Addr":{"IP":"127.0.0.1","Port":3000,"Zone":""},"Err":{}}
+		// {"Op":"read","Net":"tcp","Source":{"IP":"127.0.0.1","Port":60067,"Zone":""},
+		// "Addr":{"IP":"127.0.0.1","Port":3000,"Zone":""},"Err":{}}
 		// instead of
 		// read tcp 127.0.0.1:60067->127.0.0.1:3000: i/o timeout
 		// Noticed in https://github.com/fortio/fortio/issues/913

--- a/logger.go
+++ b/logger.go
@@ -653,6 +653,19 @@ func (v ValueType[T]) String() string {
 		return fmt.Sprint(s)
 	case string:
 		return fmt.Sprintf("%q", s)
+	case error:
+		// Sadly structured errors like nettwork error don't have the reason in
+		// the exposed struct/JSON - ie on gets
+		// {"Op":"read","Net":"tcp","Source":{"IP":"127.0.0.1","Port":60067,"Zone":""},"Addr":{"IP":"127.0.0.1","Port":3000,"Zone":""},"Err":{}}
+		// instead of
+		// read tcp 127.0.0.1:60067->127.0.0.1:3000: i/o timeout
+		// Noticed in https://github.com/fortio/fortio/issues/913
+		_, hasMarshaller := s.(json.Marshaler)
+		if hasMarshaller {
+			return toJSON(v.Val)
+		} else {
+			return fmt.Sprintf("%q", s.Error())
+		}
 	/* It's all handled by json fallback now even though slightly more expensive at runtime, it's a lot simpler */
 	default:
 		return toJSON(v.Val) // was fmt.Sprintf("%q", fmt.Sprint(v.Val))

--- a/logger.go
+++ b/logger.go
@@ -637,11 +637,8 @@ func toJSON(v any) string {
 		return strconv.Quote(fmt.Sprintf("ERR marshaling %v: %v", v, err))
 	}
 	str := string(bytes)
-	// This is kinda hacky way to handle both structured and custom serialization errors, and
-	// struct with no public fields for which we need to call Error() to get a useful string.
-	if e, isError := v.(error); isError && str == "{}" {
-		return fmt.Sprintf("%q", e.Error())
-	}
+	// We now handle errors before calling toJSON: if there is a marshaller we use it
+	// otherwise we use the string from .Error()
 	return str
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -757,8 +757,14 @@ type customError struct {
 	Code int
 }
 
+type customErrorAlias customError
+
 func (e customError) Error() string {
 	return fmt.Sprintf("custom error %s (code %d)", e.Msg, e.Code)
+}
+
+func (e customError) MarshalJSON() ([]byte, error) {
+	return json.Marshal(customErrorAlias(e))
 }
 
 func TestSerializationOfError(t *testing.T) {


### PR DESCRIPTION
use .Error() unless explicit marshaller is found - this will avoid missing the message for a net.OpError read for instance

Noticed in https://github.com/fortio/fortio/issues/913