### PR TITLE
tinygo support, goroutine hack change, fix panic for invalid stderr, add test

### DIFF
--- a/console_logging.go
+++ b/console_logging.go
@@ -88,6 +88,14 @@ var (
 	Color = false
 )
 
+func IsValid(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+	_, err := file.Stat()
+	return err == nil
+}
+
 // ConsoleLogging is a utility to check if the current logger output is a console (terminal).
 func ConsoleLogging() bool {
 	f, ok := jWriter.w.(*os.File)

--- a/console_logging.go
+++ b/console_logging.go
@@ -88,7 +88,9 @@ var (
 	Color = false
 )
 
-func IsValid(file *os.File) bool {
+// Is the file (e.g os.StdErr) Stat()able so we can detect if it's a tty or not.
+// If not we switch in init() to Stdout.
+func isValid(file *os.File) bool {
 	if file == nil {
 		return false
 	}

--- a/console_logging.go
+++ b/console_logging.go
@@ -94,7 +94,10 @@ func ConsoleLogging() bool {
 	if !ok {
 		return false
 	}
-	s, _ := f.Stat()
+	s, err := f.Stat()
+	if err != nil {
+		return false
+	}
 	return (s.Mode() & os.ModeCharDevice) == os.ModeCharDevice
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module fortio.org/log
 
 go 1.18
 
-require fortio.org/struct2env v0.4.1
+require (
+	fortio.org/struct2env v0.4.1
+	github.com/kortschak/goroutine v1.1.2
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 fortio.org/struct2env v0.4.1 h1:rJludAMO5eBvpWplWEQNqoVDFZr4RWMQX7RUapgZyc0=
 fortio.org/struct2env v0.4.1/go.mod h1:lENUe70UwA1zDUCX+8AsO663QCFqYaprk5lnPhjD410=
+github.com/kortschak/goroutine v1.1.2 h1:lhllcCuERxMIK5cYr8yohZZScL1na+JM5JYPRclWjck=
+github.com/kortschak/goroutine v1.1.2/go.mod h1:zKpXs1FWN/6mXasDQzfl7g0LrGFIOiA6cLs9eXKyaMY=

--- a/goroutine/gid.go
+++ b/goroutine/gid.go
@@ -1,8 +1,12 @@
+//go:build !tinygo
+
 package goroutine
 
 import (
 	"github.com/kortschak/goroutine" // Rely on and forward to the original rather than maintain our own copy.
 )
+
+const IsTinyGo = false
 
 // ID returns the runtime ID of the calling goroutine.
 func ID() int64 {

--- a/goroutine/gid.go
+++ b/goroutine/gid.go
@@ -1,52 +1,10 @@
-// Copyright ©2020 Dan Kortschak. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// Package goroutine provides a single function that will return the runtime's
-// ID number for the calling goroutine.
-//
-// The implementation is derived from Laevus Dexter's comment in Gophers' Slack #darkarts,
-// https://gophers.slack.com/archives/C1C1YSQBT/p1593885226448300 post which linked to
-// this playground snippet https://play.golang.org/p/CSOp9wyzydP.
 package goroutine
 
 import (
-	"reflect"
-	"unsafe"
+	"github.com/kortschak/goroutine" // Rely on and forward to the original rather than maintain our own copy.
 )
 
 // ID returns the runtime ID of the calling goroutine.
 func ID() int64 {
-	return *(*int64)(add(getg(), goidoff))
+	return goroutine.ID()
 }
-
-//go:nosplit
-func getg() unsafe.Pointer {
-	return *(*unsafe.Pointer)(add(getm(), curgoff))
-}
-
-//go:linkname add runtime.add
-//go:nosplit
-func add(p unsafe.Pointer, x uintptr) unsafe.Pointer
-
-//go:linkname getm runtime.getm
-//go:nosplit
-func getm() unsafe.Pointer
-
-var (
-	curgoff = offset("*runtime.m", "curg")
-	goidoff = offset("*runtime.g", "goid")
-)
-
-// offset returns the offset into typ for the given field.
-func offset(typ, field string) uintptr {
-	rt := toType(typesByString(typ)[0])
-	f, _ := rt.Elem().FieldByName(field)
-	return f.Offset
-}
-
-//go:linkname typesByString reflect.typesByString
-func typesByString(s string) []unsafe.Pointer
-
-//go:linkname toType reflect.toType
-func toType(t unsafe.Pointer) reflect.Type

--- a/goroutine/gid_test.go
+++ b/goroutine/gid_test.go
@@ -44,8 +44,9 @@ var testID int64
 // goid returns the goroutine ID extracted from a stack trace.
 func goid() int64 {
 	if IsTinyGo {
+		// pretty horrible test that aligns with the implementation, but at least it tests we get 1,2,3... different numbers.
 		testID++
-		return testID // pretty horrible test that aligns with the implementation, but at least it tests we get 1,2,3... different numbers.
+		return testID
 	}
 	var buf [64]byte
 	n := runtime.Stack(buf[:], false)

--- a/goroutine/gid_tinygo.go
+++ b/goroutine/gid_tinygo.go
@@ -12,7 +12,10 @@ const IsTinyGo = true
 var (
 	counter int64
 	mapping = make(map[uintptr]int64)
-	lock    sync.Mutex
+	// TinyGo at the moment is single threaded so this is not needed but it's good to have anyway
+	// in case that changes. It does had ~5ns (from 20ns vs 4ns big go) but it's better to be correct.
+	// In theory the mutex could be noop on platforms where everything is single threaded.
+	lock sync.Mutex
 )
 
 func ID() int64 {

--- a/goroutine/gid_tinygo.go
+++ b/goroutine/gid_tinygo.go
@@ -33,5 +33,7 @@ func ID() int64 {
 	//return int64(uintptr(currentTask()))
 }
 
+// Call https://github.com/tinygo-org/tinygo/blob/v0.32.0/src/internal/task/task_stack.go#L39
+//
 //go:linkname currentTask internal/task.Current
 func currentTask() unsafe.Pointer

--- a/goroutine/gid_tinygo.go
+++ b/goroutine/gid_tinygo.go
@@ -12,9 +12,9 @@ const IsTinyGo = true
 var (
 	counter int64
 	mapping = make(map[uintptr]int64)
-	// TinyGo at the moment is single threaded so this is not needed but it's good to have anyway
-	// in case that changes. It does had ~5ns (from 20ns vs 4ns big go) but it's better to be correct.
-	// In theory the mutex could be noop on platforms where everything is single threaded.
+	// TinyGo at the moment is single threaded, so this is not needed, but it's good to have anyway
+	// in case that changes. It does add ~5ns (from 20ns vs 4ns big go) but it's better to be correct.
+	// In theory, the mutex could be noop on platforms where everything is single threaded.
 	lock sync.Mutex
 )
 

--- a/goroutine/gid_tinygo.go
+++ b/goroutine/gid_tinygo.go
@@ -20,7 +20,7 @@ var (
 
 func ID() int64 {
 	task := uintptr(currentTask())
-	lock.Lock()
+	lock.Lock() // explicit minimal critical section without using defer, on purpose.
 	if id, ok := mapping[task]; ok {
 		lock.Unlock()
 		return id

--- a/goroutine/gid_tinygo.go
+++ b/goroutine/gid_tinygo.go
@@ -1,0 +1,34 @@
+//go:build tinygo
+
+package goroutine
+
+import (
+	"sync"
+	"unsafe"
+)
+
+const IsTinyGo = true
+
+var (
+	counter int64
+	mapping = make(map[uintptr]int64)
+	lock    sync.Mutex
+)
+
+func ID() int64 {
+	task := uintptr(currentTask())
+	lock.Lock()
+	if id, ok := mapping[task]; ok {
+		lock.Unlock()
+		return id
+	}
+	counter++
+	mapping[task] = counter
+	lock.Unlock()
+	return counter
+	// or, super fast but ugly large numbers/pointers:
+	//return int64(uintptr(currentTask()))
+}
+
+//go:linkname currentTask internal/task.Current
+func currentTask() unsafe.Pointer

--- a/logger.go
+++ b/logger.go
@@ -174,6 +174,9 @@ func (l *JSONEntry) Time() time.Time {
 
 //nolint:gochecknoinits // needed
 func init() {
+	if !IsValid(os.Stderr) { // wasm in browser case for instance
+		SetOutput(os.Stdout) // this could also be invalid too but... we tried.
+	}
 	setLevel(Info) // starting value
 	levelToStrM = make(map[string]Level, 2*len(LevelToStrA))
 	JSONStringLevelToLevel = make(map[string]Level, len(LevelToJSON)-1) // -1 to not reverse info to NoLevel

--- a/logger.go
+++ b/logger.go
@@ -174,7 +174,7 @@ func (l *JSONEntry) Time() time.Time {
 
 //nolint:gochecknoinits // needed
 func init() {
-	if !IsValid(os.Stderr) { // wasm in browser case for instance
+	if !isValid(os.Stderr) { // wasm in browser case for instance
 		SetOutput(os.Stdout) // this could also be invalid too but... we tried.
 	}
 	setLevel(Info) // starting value

--- a/logger.go
+++ b/logger.go
@@ -175,7 +175,7 @@ func (l *JSONEntry) Time() time.Time {
 //nolint:gochecknoinits // needed
 func init() {
 	if !isValid(os.Stderr) { // wasm in browser case for instance
-		SetOutput(os.Stdout) // this could also be invalid too but... we tried.
+		SetOutput(os.Stdout) // this could also be invalid too, but... we tried.
 	}
 	setLevel(Info) // starting value
 	levelToStrM = make(map[string]Level, 2*len(LevelToStrA))

--- a/logger_test.go
+++ b/logger_test.go
@@ -941,7 +941,7 @@ func TestInvalidFile(t *testing.T) {
 	}
 }
 
-// io.Discard but specially known to by logger optimizations for instance.
+// like io.Discard except io.Discard is checked for by logger optimizations and we want to avoid that.
 type discard struct{}
 
 func (discard) Write(p []byte) (int, error) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -942,6 +942,7 @@ func TestInvalidFile(t *testing.T) {
 }
 
 // like io.Discard except io.Discard is checked for by logger optimizations and we want to avoid that.
+// e.g. https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/log/log.go;l=84
 type discard struct{}
 
 func (discard) Write(p []byte) (int, error) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -944,8 +944,12 @@ func TestInvalidFile(t *testing.T) {
 	}
 }
 
-// like io.Discard except io.Discard is checked for by logger optimizations and we want to avoid that.
-// e.g. https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/log/log.go;l=84
+// --- Benchmarks
+
+// This `discard` is like io.Discard, except that io.Discard is checked explicitly
+// (e.g. https://cs.opensource.google/go/go/+/refs/tags/go1.22.5:src/log/log.go;l=84)
+// in logger optimizations and we want to measure the actual production
+// of messages.
 type discard struct{}
 
 func (discard) Write(p []byte) (int, error) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -931,6 +931,9 @@ func TestConfigFromEnvOk(t *testing.T) {
 }
 
 func TestInvalidFile(t *testing.T) {
+	if isValid(nil) {
+		t.Errorf("expected nil to be invalid")
+	}
 	prev := jWriter.w
 	invalidFile := os.NewFile(^uintptr(0), "invalid-file")
 	jWriter.w = invalidFile

--- a/logger_test.go
+++ b/logger_test.go
@@ -930,6 +930,17 @@ func TestConfigFromEnvOk(t *testing.T) {
 	}
 }
 
+func TestInvalidFile(t *testing.T) {
+	prev := jWriter.w
+	invalidFile := os.NewFile(^uintptr(0), "invalid-file")
+	jWriter.w = invalidFile
+	b := ConsoleLogging()
+	jWriter.w = prev
+	if b {
+		t.Errorf("expected not to be console logging")
+	}
+}
+
 // io.Discard but specially known to by logger optimizations for instance.
 type discard struct{}
 


### PR DESCRIPTION
Fixes #65

For tinygo (once debug.Buildinfo is fixed in https://github.com/tinygo-org/tinygo/pull/4343) the issue was the linkname hacks that work for go do not exist, but there is instead a `internal/task.Current` that we use but convert to an id because... folks aren't convinced we need an id (even though we do...)

Also switched to letting https://github.com/kortschak/goroutine deal with maintaining the hack (adds a dependency but... oh well)