### PR TITLE
Allow an additional LOGGER_IGNORE_CLI_MODE env var to be set to true …

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -79,6 +79,9 @@ type LogConfig struct {
 	CombineRequestAndResponse bool
 	// String version of the log level, used for setting from environment.
 	Level string
+	// If true, ignore SetDefaultsForClientTools() calls even if set. Allows full line/file debug and basically
+	// imply configuration from the environment variables.
+	IgnoreCliMode bool
 }
 
 // DefaultConfig() returns the default initial configuration for the logger, best suited
@@ -135,7 +138,12 @@ var (
 // to make output without caller and prefix, a default more suitable for command line tools (like dnsping).
 // Needs to be called before flag.Parse(). Caller could also use log.Printf instead of changing this
 // if not wanting to use levels. Also makes log.Fatalf just exit instead of panic.
+// Will be ignored if the environment config has been set to ignore this.
 func SetDefaultsForClientTools() {
+	if Config.IgnoreCliMode {
+		Infof("Ignoring SetDefaultsForClientTools() call due to LOGGER_IGNORE_CLI_MODE environment config")
+		return
+	}
 	Config.LogPrefix = " "
 	Config.LogFileAndLine = false
 	Config.FatalPanics = false

--- a/logger_test.go
+++ b/logger_test.go
@@ -900,6 +900,7 @@ LOGGER_FORCE_COLOR=false
 LOGGER_GOROUTINE_ID=false
 LOGGER_COMBINE_REQUEST_AND_RESPONSE=false
 LOGGER_LEVEL='Info'
+LOGGER_IGNORE_CLI_MODE=false
 `
 	if actual != expected {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
@@ -920,6 +921,8 @@ func TestConfigFromEnvError(t *testing.T) {
 
 func TestConfigFromEnvOk(t *testing.T) {
 	t.Setenv("LOGGER_LEVEL", "verbose")
+	t.Setenv("LOGGER_IGNORE_CLI_MODE", "true")
+	t.Setenv("LOGGER_LOG_FILE_AND_LINE", "true") // earlier test disable this
 	var buf bytes.Buffer
 	SetOutput(&buf)
 	configFromEnv()
@@ -927,6 +930,16 @@ func TestConfigFromEnvOk(t *testing.T) {
 	expected := "Log level set from environment LOGGER_LEVEL to Verbose"
 	if !strings.Contains(actual, expected) {
 		t.Errorf("unexpected:\n%s\nvs:\n%s\n", actual, expected)
+	}
+	if !Config.IgnoreCliMode {
+		t.Errorf("expected IgnoreCLIMode to be true")
+	}
+	if Config.LogFileAndLine != true {
+		t.Errorf("expected initial LogFileAndLine to be true")
+	}
+	SetDefaultsForClientTools() // should be no-op, ie not turn off LogFileAndLine etc
+	if Config.LogFileAndLine != true {
+		t.Errorf("expected LogFileAndLine to still be true after SetDefaultsForClientTools with LOGGER_IGNORE_CLI_MODE=true")
 	}
 }
 


### PR DESCRIPTION
…to ignore SetDefaultsForClientTools like in cli so one can get line numbers etc despite cli mode

fixes #68 