### PR TITLE
When stderr is redirected to a file, don't spam Ignoring SetDefaultsForClientTools() unless loglevel is verbose

### DIFF
--- a/console_logging.go
+++ b/console_logging.go
@@ -40,7 +40,7 @@ type color struct {
 var (
 	// these should really be constants but go doesn't have constant structs, arrays etc...
 
-	// ANSI color codes.
+	// ANSIColors are ANSI color codes.
 	// This isn't meant to be used directly and is here only to document the names of the struct.
 	// Use the Colors variable instead.
 	ANSIColors = color{
@@ -57,12 +57,12 @@ var (
 		DarkGray:  "\033[90m",
 	}
 
-	// ANSI color codes or empty depending on ColorMode.
+	// Colors are ANSI color codes or empty depending on ColorMode.
 	// These will be reset to empty string if color is disabled (see ColorMode() and SetColorMode()).
 	// Start with actual colors, will be reset to empty if color is disabled.
 	Colors = ANSIColors
 
-	// Mapping of log levels to color.
+	// LevelToColor is the mapping of log levels to color.
 	LevelToColor = []string{
 		Colors.Gray,
 		Colors.Cyan,
@@ -73,7 +73,7 @@ var (
 		Colors.BrightRed,
 		Colors.Green, // NoLevel log.Printf
 	}
-	// Used for color version of console logging.
+	// LevelToText is used for color version of console logging.
 	LevelToText = []string{
 		"DBG",
 		"VRB",
@@ -84,7 +84,7 @@ var (
 		"FTL",
 		"",
 	}
-	// Cached flag for whether to use color output or not.
+	// Color is a cached flag for whether to use color output or not.
 	Color = false
 )
 
@@ -158,7 +158,7 @@ func colorGID() string {
 	return Colors.Gray + fmt.Sprintf("r%d ", goroutine.ID())
 }
 
-// Longer version when colorizing on console of the level text.
+// ColorLevelToStr returns a longer version when colorizing on console of the level text.
 func ColorLevelToStr(lvl Level) string {
 	if lvl == NoLevel {
 		return Colors.DarkGray

--- a/http_logging.go
+++ b/http_logging.go
@@ -136,7 +136,7 @@ func LogResponse[T *ResponseRecorder | *http.Response](r T, msg string, extraAtt
 	s(Info, false, Config.JSON, msg, attr...)
 }
 
-// Can be used (and is used by LogAndCall()) to wrap a http.ResponseWriter to record status code and size.
+// ResponseRecorder can be used (and is used by LogAndCall()) to wrap a http.ResponseWriter to record status code and size.
 type ResponseRecorder struct {
 	w             http.ResponseWriter
 	startTime     time.Time
@@ -164,7 +164,7 @@ func (rr *ResponseRecorder) WriteHeader(code int) {
 	rr.StatusCode = code
 }
 
-// Implement http.Flusher interface.
+// Flush implements http.Flusher interface.
 func (rr *ResponseRecorder) Flush() {
 	if f, ok := rr.w.(http.Flusher); ok {
 		f.Flush()
@@ -220,7 +220,7 @@ type logWriter struct {
 	level  Level
 }
 
-// Returns a Std logger that will log to the given level with the given source attribute.
+// NewStdLogger returns a Std logger that will log to the given level with the given source attribute.
 // Can be passed for instance to net/http/httputil.ReverseProxy.ErrorLog.
 func NewStdLogger(source string, level Level) *log.Logger {
 	return log.New(logWriter{source, level}, "", 0)

--- a/logger.go
+++ b/logger.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*
-Fortio's log is simple logger built on top of go's default one with
+Package log is Fortio's simple logger built on top of go's default one with
 additional opinionated levels similar to glog but simpler to use and configure.
 
 See [Config] object for options like whether to include line number and file name of caller or not etc
@@ -56,7 +56,10 @@ const (
 	Critical
 	Fatal
 	NoLevel
-	// Prefix for all config from environment,
+)
+
+const (
+	// EnvPrefix is the prefix for all config from environment,
 	// e.g NoTimestamp becomes LOGGER_NO_TIMESTAMP.
 	EnvPrefix = "LOGGER_"
 )
@@ -108,7 +111,7 @@ func DefaultConfig() *LogConfig {
 
 var (
 	Config = DefaultConfig()
-	// Used for dynamic flag setting as strings and validation.
+	// LevelToStrA is used for dynamic flag setting as strings and validation.
 	LevelToStrA = []string{
 		"Debug",
 		"Verbose",
@@ -120,7 +123,7 @@ var (
 	}
 	levelToStrM   map[string]Level
 	levelInternal int32
-	// Used for JSON logging.
+	// LevelToJSON is used for JSON logging.
 	LevelToJSON = []string{
 		// matching https://github.com/grafana/grafana/blob/main/docs/sources/explore/logs-integration.md
 		// adding the "" around to save processing when generating json. using short names to save some bytes.
@@ -133,7 +136,7 @@ var (
 		"\"fatal\"",
 		"\"info\"", // For Printf / NoLevel JSON output
 	}
-	// Reverse mapping of level string used in JSON to Level. Used by https://github.com/fortio/logc
+	// JSONStringLevelToLevel is the reverse mapping of level string used in JSON to Level. Used by https://github.com/fortio/logc
 	// to interpret and colorize pre existing JSON logs.
 	JSONStringLevelToLevel map[string]Level
 )
@@ -306,7 +309,7 @@ func (f *flagValidation) Set(inp string) error {
 
 // --- End of code/types needed string to level custom flag validation section ---
 
-// Sets level from string (called by dflags).
+// SetLogLevelStr sets level from string (called by dflags).
 // Use https://pkg.go.dev/fortio.org/dflag/dynloglevel#LoggerFlagSetup to set up
 // `-loglevel` as a dynamic flag (or an example of how this function is used).
 func SetLogLevelStr(str string) error {
@@ -416,7 +419,7 @@ func jsonWriteBytes(msg []byte) {
 	jWriter.mutex.Unlock()
 }
 
-// Converts a time.Time to a float64 timestamp (seconds since epoch at microsecond resolution).
+// TimeToTS converts a time.Time to a float64 timestamp (seconds since epoch at microsecond resolution).
 // This is what is used in JSONEntry.TS.
 func TimeToTS(t time.Time) float64 {
 	// note that nanos like 1688763601.199999400 become 1688763601.1999996 in float64 (!)
@@ -580,7 +583,7 @@ func Fatalf(format string, rest ...interface{}) {
 	Config.FatalExit(1)
 }
 
-// FErrF logs a fatal error and returns 1.
+// FErrf logs a fatal error and returns 1.
 // meant for cli main functions written like:
 //
 //	func main() { os.Exit(Main()) }
@@ -645,7 +648,7 @@ func Str(key, value string) KeyVal {
 	return Any(key, value)
 }
 
-// Few more slog style short cuts.
+// Int is one of the few more slog style short cuts.
 func Int(key string, value int) KeyVal {
 	return Any(key, value)
 }
@@ -681,7 +684,7 @@ type ValueType[T ValueTypes] struct {
 	Val T
 }
 
-// Our original name, now switched to slog style Any.
+// Attr is our original name, now switched to slog style Any.
 func Attr[T ValueTypes](key string, value T) KeyVal {
 	return Any(key, value)
 }


### PR DESCRIPTION
Avoids
```json
{"ts":1762733319.925241,"level":"info","r":1,"file":"logger.go","line":162,"msg":"Ignoring SetDefaultsForClientTools() call due to non console logging"}
```